### PR TITLE
xds: Client watcher API changes 

### DIFF
--- a/cronet/build.gradle
+++ b/cronet/build.gradle
@@ -58,7 +58,7 @@ dependencies {
 
 task javadocs(type: Javadoc) {
     source = android.sourceSets.main.java.srcDirs
-    classpath += files(android.getBootClasspath())
+    // classpath += files(android.getBootClasspath())
     classpath += files({
         android.libraryVariants.collect { variant ->
             variant.javaCompileProvider.get().classpath

--- a/cronet/build.gradle
+++ b/cronet/build.gradle
@@ -58,7 +58,7 @@ dependencies {
 
 task javadocs(type: Javadoc) {
     source = android.sourceSets.main.java.srcDirs
-    // classpath += files(android.getBootClasspath())
+    classpath += files(android.getBootClasspath())
     classpath += files({
         android.libraryVariants.collect { variant ->
             variant.javaCompileProvider.get().classpath

--- a/xds/src/main/java/io/grpc/xds/XdsDependencyManager.java
+++ b/xds/src/main/java/io/grpc/xds/XdsDependencyManager.java
@@ -633,7 +633,8 @@ final class XdsDependencyManager implements XdsConfig.XdsClusterSubscriptionRegi
     @Nullable
     private StatusOr<T> data;
     @Nullable
-    private Status ambientError; // To hold transient errors
+    @SuppressWarnings("unused")
+    private Status ambientError;
 
 
     private XdsWatcherBase(XdsResourceType<T> type, String resourceName) {

--- a/xds/src/main/java/io/grpc/xds/XdsDependencyManager.java
+++ b/xds/src/main/java/io/grpc/xds/XdsDependencyManager.java
@@ -674,7 +674,7 @@ final class XdsDependencyManager implements XdsConfig.XdsClusterSubscriptionRegi
           String.format("Ambient error for %s: %s. Details: %s%s",
               toContextString(),
               error.getCode(),
-              error.getDescription(),
+              error.getDescription() != null ? error.getDescription() : "",
               nodeInfo()));
     }
 

--- a/xds/src/main/java/io/grpc/xds/XdsDependencyManager.java
+++ b/xds/src/main/java/io/grpc/xds/XdsDependencyManager.java
@@ -653,11 +653,10 @@ final class XdsDependencyManager implements XdsConfig.XdsClusterSubscriptionRegi
       } else {
         Status status = update.getStatus();
         Status translatedStatus = Status.UNAVAILABLE.withDescription(
-            String.format("Error retrieving %s: %s. Details: %s%s",
+            String.format("Error retrieving %s: %s. Details: %s",
                 toContextString(),
                 status.getCode(),
-                status.getDescription() != null ? status.getDescription() : "",
-                nodeInfo()));
+                status.getDescription() != null ? status.getDescription() : ""));
 
         data = StatusOr.fromStatus(translatedStatus);
       }

--- a/xds/src/main/java/io/grpc/xds/XdsDependencyManager.java
+++ b/xds/src/main/java/io/grpc/xds/XdsDependencyManager.java
@@ -653,10 +653,11 @@ final class XdsDependencyManager implements XdsConfig.XdsClusterSubscriptionRegi
       } else {
         Status status = update.getStatus();
         Status translatedStatus = Status.UNAVAILABLE.withDescription(
-            String.format("Error retrieving %s: %s. Details: %s",
+            String.format("Error retrieving %s: %s. Details: %s%s",
                 toContextString(),
                 status.getCode(),
-                status.getDescription() != null ? status.getDescription() : ""));
+                status.getDescription() != null ? status.getDescription() : "",
+                nodeInfo()));
 
         data = StatusOr.fromStatus(translatedStatus);
       }

--- a/xds/src/main/java/io/grpc/xds/XdsDependencyManager.java
+++ b/xds/src/main/java/io/grpc/xds/XdsDependencyManager.java
@@ -632,6 +632,8 @@ final class XdsDependencyManager implements XdsConfig.XdsClusterSubscriptionRegi
 
     @Nullable
     private StatusOr<T> data;
+    @Nullable
+    private Status ambientError; // To hold transient errors
 
 
     private XdsWatcherBase(XdsResourceType<T> type, String resourceName) {
@@ -640,42 +642,39 @@ final class XdsDependencyManager implements XdsConfig.XdsClusterSubscriptionRegi
     }
 
     @Override
-    public void onError(Status error) {
-      checkNotNull(error, "error");
+    public void onResourceChanged(StatusOr<T> update) {
       if (cancelled) {
         return;
       }
-      // Don't update configuration on error, if we've already received configuration
-      if (!hasDataValue()) {
-        this.data = StatusOr.fromStatus(Status.UNAVAILABLE.withDescription(
-            String.format("Error retrieving %s: %s: %s",
-              toContextString(), error.getCode(), error.getDescription())));
-        maybePublishConfig();
-      }
-    }
+      ambientError = null;
+      if (update.hasValue()) {
+        data = update;
+        subscribeToChildren(update.getValue());
+      } else {
+        Status status = update.getStatus();
+        Status translatedStatus = Status.UNAVAILABLE.withDescription(
+            String.format("Error retrieving %s: %s. Details: %s%s",
+                toContextString(),
+                status.getCode(),
+                status.getDescription() != null ? status.getDescription() : "",
+                nodeInfo()));
 
-    @Override
-    public void onResourceDoesNotExist(String resourceName) {
-      if (cancelled) {
-        return;
+        data = StatusOr.fromStatus(translatedStatus);
       }
-
-      checkArgument(this.resourceName.equals(resourceName), "Resource name does not match");
-      this.data = StatusOr.fromStatus(Status.UNAVAILABLE.withDescription(
-          toContextString() + " does not exist" + nodeInfo()));
       maybePublishConfig();
     }
 
     @Override
-    public void onChanged(T update) {
-      checkNotNull(update, "update");
+    public void onAmbientError(Status error) {
       if (cancelled) {
         return;
       }
-
-      this.data = StatusOr.fromValue(update);
-      subscribeToChildren(update);
-      maybePublishConfig();
+      ambientError = error.withDescription(
+          String.format("Ambient error for %s: %s. Details: %s%s",
+              toContextString(),
+              error.getCode(),
+              error.getDescription(),
+              nodeInfo()));
     }
 
     protected abstract void subscribeToChildren(T update);

--- a/xds/src/main/java/io/grpc/xds/client/BootstrapperImpl.java
+++ b/xds/src/main/java/io/grpc/xds/client/BootstrapperImpl.java
@@ -256,7 +256,7 @@ public abstract class BootstrapperImpl extends Bootstrapper {
       Object implSpecificConfig = getImplSpecificConfig(serverConfig, serverUri);
 
       boolean resourceTimerIsTransientError = false;
-      boolean ignoreResourceDeletion = xdsDataErrorHandlingEnabled;
+      boolean ignoreResourceDeletion = false;
       // "For forward compatibility reasons, the client will ignore any entry in the list that it
       // does not understand, regardless of type."
       List<?> serverFeatures = JsonUtil.getList(serverConfig, "server_features");

--- a/xds/src/main/java/io/grpc/xds/client/BootstrapperImpl.java
+++ b/xds/src/main/java/io/grpc/xds/client/BootstrapperImpl.java
@@ -256,13 +256,15 @@ public abstract class BootstrapperImpl extends Bootstrapper {
       Object implSpecificConfig = getImplSpecificConfig(serverConfig, serverUri);
 
       boolean resourceTimerIsTransientError = false;
-      boolean ignoreResourceDeletion = false;
+      boolean ignoreResourceDeletion = xdsDataErrorHandlingEnabled;
       // "For forward compatibility reasons, the client will ignore any entry in the list that it
       // does not understand, regardless of type."
       List<?> serverFeatures = JsonUtil.getList(serverConfig, "server_features");
       if (serverFeatures != null) {
         logger.log(XdsLogLevel.INFO, "Server features: {0}", serverFeatures);
-        ignoreResourceDeletion = serverFeatures.contains(SERVER_FEATURE_IGNORE_RESOURCE_DELETION);
+        if (serverFeatures.contains(SERVER_FEATURE_IGNORE_RESOURCE_DELETION)) {
+          ignoreResourceDeletion = true;
+        }
         resourceTimerIsTransientError = xdsDataErrorHandlingEnabled
             && serverFeatures.contains(SERVER_FEATURE_RESOURCE_TIMER_IS_TRANSIENT_ERROR);
       }

--- a/xds/src/main/java/io/grpc/xds/client/ControlPlaneClient.java
+++ b/xds/src/main/java/io/grpc/xds/client/ControlPlaneClient.java
@@ -475,7 +475,6 @@ final class ControlPlaneClient {
       close(status.asException());
       rpcRetryTimer =
           syncContext.schedule(new RpcRetryTask(), delayNanos, TimeUnit.NANOSECONDS, timeService);
-      // Notify the handler of the stream closure before cleaning up the stream state.
       xdsResponseHandler.handleStreamClosed(statusToPropagate, !responseReceived);
     }
 

--- a/xds/src/main/java/io/grpc/xds/client/ControlPlaneClient.java
+++ b/xds/src/main/java/io/grpc/xds/client/ControlPlaneClient.java
@@ -456,7 +456,7 @@ final class ControlPlaneClient {
       Status statusToPropagate = status;
       if (!responseReceived && status.isOk()) {
         // If the ADS stream is closed with OK without ever having received a response,
-        // it is a connectivity error.
+        // it is a connectivity error (see gRFC A57).
         statusToPropagate = Status.UNAVAILABLE.withDescription(
             "ADS stream closed with OK before receiving a response");
       }

--- a/xds/src/main/java/io/grpc/xds/client/ControlPlaneClient.java
+++ b/xds/src/main/java/io/grpc/xds/client/ControlPlaneClient.java
@@ -472,12 +472,11 @@ final class ControlPlaneClient {
       // concurrently with the stopwatch and schedule.
       long elapsed = stopwatch.elapsed(TimeUnit.NANOSECONDS);
       long delayNanos = Math.max(0, retryBackoffPolicy.nextBackoffNanos() - elapsed);
+      close(status.asException());
       rpcRetryTimer =
           syncContext.schedule(new RpcRetryTask(), delayNanos, TimeUnit.NANOSECONDS, timeService);
-
       // Notify the handler of the stream closure before cleaning up the stream state.
       xdsResponseHandler.handleStreamClosed(statusToPropagate, !responseReceived);
-      close(status.asException());
     }
 
     private void close(Exception error) {

--- a/xds/src/main/java/io/grpc/xds/client/ControlPlaneClient.java
+++ b/xds/src/main/java/io/grpc/xds/client/ControlPlaneClient.java
@@ -453,34 +453,19 @@ final class ControlPlaneClient {
         stopwatch.reset();
       }
 
-      Status newStatus = status;
-      if (responseReceived) {
-        // A closed ADS stream after a successful response is not considered an error. Servers may
-        // close streams for various reasons during normal operation, such as load balancing or
-        // underlying connection hitting its max connection age limit  (see gRFC A9).
-        if (!status.isOk()) {
-          newStatus = Status.OK;
-          logger.log( XdsLogLevel.DEBUG, "ADS stream closed with error {0}: {1}. However, a "
-              + "response was received, so this will not be treated as an error. Cause: {2}",
-              status.getCode(), status.getDescription(), status.getCause());
-        } else {
-          logger.log(XdsLogLevel.DEBUG,
-              "ADS stream closed by server after a response was received");
-        }
-      } else {
-        // If the ADS stream is closed without ever having received a response from the server, then
-        // the XdsClient should consider that a connectivity error (see gRFC A57).
-        inError = true;
-        if (status.isOk()) {
-          newStatus = Status.UNAVAILABLE.withDescription(
-              "ADS stream closed with OK before receiving a response");
-        }
-        logger.log(
-            XdsLogLevel.ERROR, "ADS stream failed with status {0}: {1}. Cause: {2}",
-            newStatus.getCode(), newStatus.getDescription(), newStatus.getCause());
+      Status statusToPropagate = status;
+      if (!responseReceived && status.isOk()) {
+        // If the ADS stream is closed with OK without ever having received a response,
+        // it is a connectivity error.
+        statusToPropagate = Status.UNAVAILABLE.withDescription(
+            "ADS stream closed with OK before receiving a response");
       }
-
-      close(newStatus.asException());
+      if (!statusToPropagate.isOk()) {
+        inError = true;
+        logger.log(XdsLogLevel.ERROR, "ADS stream failed with status {0}: {1}. Cause: {2}",
+            statusToPropagate.getCode(), statusToPropagate.getDescription(),
+            statusToPropagate.getCause());
+      }
 
       // FakeClock in tests isn't thread-safe. Schedule the retry timer before notifying callbacks
       // to avoid TSAN races, since tests may wait until callbacks are called but then would run
@@ -490,7 +475,9 @@ final class ControlPlaneClient {
       rpcRetryTimer =
           syncContext.schedule(new RpcRetryTask(), delayNanos, TimeUnit.NANOSECONDS, timeService);
 
-      xdsResponseHandler.handleStreamClosed(newStatus, !responseReceived);
+      // Notify the handler of the stream closure before cleaning up the stream state.
+      xdsResponseHandler.handleStreamClosed(statusToPropagate, !responseReceived);
+      close(status.asException());
     }
 
     private void close(Exception error) {

--- a/xds/src/main/java/io/grpc/xds/client/XdsClientImpl.java
+++ b/xds/src/main/java/io/grpc/xds/client/XdsClientImpl.java
@@ -1021,15 +1021,11 @@ public final class XdsClientImpl extends XdsClient implements ResourceStore {
       cleanUpResourceTimers(cpcClosed);
 
       if (status.isOk()) {
-        return; // Not an error.
+        return; // Not considered an error
       }
-
       if (shouldTryFallback) { // This indicates no response was received on the stream.
         metricReporter.reportServerFailure(1L, serverInfo.target());
       }
-
-      // Step 1: Determine if we even need to consider falling back.
-      // We only fall back if the stream failed AND we are missing at least one resource.
       boolean anyWatcherIsMissingResource = false;
       Collection<String> authoritiesForClosedCpc = getActiveAuthorities(cpcClosed);
       for (Map<String, ResourceSubscriber<? extends ResourceUpdate>> subscriberMap :
@@ -1044,8 +1040,6 @@ public final class XdsClientImpl extends XdsClient implements ResourceStore {
           break;
         }
       }
-
-      // Step 2: If fallback is possible and needed, attempt it for the watchers that need it.
       if (shouldTryFallback && anyWatcherIsMissingResource) {
         for (Map<String, ResourceSubscriber<? extends ResourceUpdate>> subscriberMap :
             resourceSubscribers.values()) {
@@ -1057,7 +1051,7 @@ public final class XdsClientImpl extends XdsClient implements ResourceStore {
         }
       }
 
-      // Step 3: Notify all affected watchers about the stream error.
+      // Notify all affected watchers about the stream error.
       // The subscriber's internal 'onError' will correctly delegate to the watcher's
       // 'onAmbientError' or 'onResourceChanged' based on its current state (i.e. if it has data).
       for (Map<String, ResourceSubscriber<? extends ResourceUpdate>> subscriberMap :

--- a/xds/src/main/java/io/grpc/xds/client/XdsClientImpl.java
+++ b/xds/src/main/java/io/grpc/xds/client/XdsClientImpl.java
@@ -1030,7 +1030,11 @@ public final class XdsClientImpl extends XdsClient implements ResourceStore {
       for (Map<String, ResourceSubscriber<? extends ResourceUpdate>> subscriberMap :
           resourceSubscribers.values()) {
         for (ResourceSubscriber<? extends ResourceUpdate> subscriber : subscriberMap.values()) {
-          if (subscriber.hasResult() || !authoritiesForClosedCpc.contains(subscriber.authority)) {
+          if (!authoritiesForClosedCpc.contains(subscriber.authority)) {
+            continue;
+          }
+          if (subscriber.hasResult()) {
+            subscriber.onError(status, null); // This will become an onAmbientError
             continue;
           }
 

--- a/xds/src/main/java/io/grpc/xds/client/XdsClientImpl.java
+++ b/xds/src/main/java/io/grpc/xds/client/XdsClientImpl.java
@@ -33,6 +33,7 @@ import com.google.protobuf.Any;
 import io.grpc.Internal;
 import io.grpc.InternalLogId;
 import io.grpc.Status;
+import io.grpc.StatusOr;
 import io.grpc.SynchronizationContext;
 import io.grpc.SynchronizationContext.ScheduledHandle;
 import io.grpc.internal.BackoffPolicy;
@@ -292,6 +293,7 @@ public final class XdsClientImpl extends XdsClient implements ResourceStore {
   private <T extends ResourceUpdate> CpcWithFallbackState manageControlPlaneClient(
       ResourceSubscriber<T> subscriber) {
 
+    ControlPlaneClient activeCpc = getActiveCpc(subscriber.authority);
     ControlPlaneClient cpcToUse;
     boolean didFallback = false;
     try {
@@ -311,17 +313,16 @@ public final class XdsClientImpl extends XdsClient implements ResourceStore {
       return new CpcWithFallbackState(null, false);
     }
 
-    ControlPlaneClient activeCpClient = getActiveCpc(subscriber.authority);
-    if (cpcToUse != activeCpClient) {
-      addCpcToAuthority(subscriber.authority, cpcToUse); // makes it active
-      if (activeCpClient != null) {
+    if (cpcToUse != activeCpc) {
+      addCpcToAuthority(subscriber.authority, cpcToUse);
+      if (activeCpc != null) {
         didFallback = cpcToUse != null && !cpcToUse.isInError();
         if (didFallback) {
           logger.log(XdsLogLevel.INFO, "Falling back to XDS server {0}",
               cpcToUse.getServerInfo().target());
         } else {
           logger.log(XdsLogLevel.WARNING, "No working fallback XDS Servers found from {0}",
-              activeCpClient.getServerInfo().target());
+              activeCpc.getServerInfo().target());
         }
       }
     }
@@ -730,17 +731,20 @@ public final class XdsClientImpl extends XdsClient implements ResourceStore {
       Status savedError = lastError;
       watcherExecutor.execute(() -> {
         if (errorDescription != null) {
-          watcher.onError(Status.INVALID_ARGUMENT.withDescription(errorDescription));
-          return;
-        }
-        if (savedError != null) {
-          watcher.onError(savedError);
+          watcher.onResourceChanged(StatusOr.fromStatus(
+              Status.INVALID_ARGUMENT.withDescription(errorDescription)));
           return;
         }
         if (savedData != null) {
-          notifyWatcher(watcher, savedData);
+          watcher.onResourceChanged(StatusOr.fromValue(savedData));
+          if (savedError != null) {
+            watcher.onAmbientError(savedError);
+          }
+        } else if (savedError != null) {
+          watcher.onResourceChanged(StatusOr.fromStatus(savedError));
         } else if (savedAbsent) {
-          watcher.onResourceDoesNotExist(resource);
+          watcher.onResourceChanged(StatusOr.fromStatus(
+              Status.NOT_FOUND.withDescription("Resource " + resource + " does not exist")));
         }
       });
     }
@@ -768,8 +772,8 @@ public final class XdsClientImpl extends XdsClient implements ResourceStore {
         public void run() {
           logger.log(XdsLogLevel.INFO, "{0} resource {1} initial fetch timeout",
               type, resource);
-          respTimer = null;
           onAbsent(null, activeCpc.getServerInfo());
+          respTimer = null;
         }
 
         @Override
@@ -825,8 +829,8 @@ public final class XdsClientImpl extends XdsClient implements ResourceStore {
       }
       ResourceUpdate oldData = this.data;
       this.data = parsedResource.getResourceUpdate();
-      this.metadata = ResourceMetadata
-          .newResourceMetadataAcked(parsedResource.getRawResource(), version, updateTime);
+      this.metadata = ResourceMetadata.newResourceMetadataAcked(
+          parsedResource.getRawResource(), version, updateTime);
       absent = false;
       lastError = null;
       if (resourceDeletionIgnored) {
@@ -836,11 +840,14 @@ public final class XdsClientImpl extends XdsClient implements ResourceStore {
         resourceDeletionIgnored = false;
       }
       if (!Objects.equals(oldData, data)) {
-        for (ResourceWatcher<T> watcher : watchers.keySet()) {
+        StatusOr<T> update = StatusOr.fromValue(data);
+        for (Map.Entry<ResourceWatcher<T>, Executor> entry : watchers.entrySet()) {
+          ResourceWatcher<T> watcher = entry.getKey();
+          Executor executor = entry.getValue();
           processingTracker.startTask();
-          watchers.get(watcher).execute(() -> {
+          executor.execute(() -> {
             try {
-              notifyWatcher(watcher, data);
+              watcher.onResourceChanged(update); // Call the new method
             } finally {
               processingTracker.onComplete();
             }
@@ -871,6 +878,9 @@ public final class XdsClientImpl extends XdsClient implements ResourceStore {
               serverInfo.target(), type, resource);
           resourceDeletionIgnored = true;
         }
+        Status deletionStatus = Status.NOT_FOUND.withDescription(
+            "Resource " + resource + " deleted from server");
+        onAmbientError(deletionStatus, processingTracker);
         return;
       }
 
@@ -879,21 +889,30 @@ public final class XdsClientImpl extends XdsClient implements ResourceStore {
         data = null;
         absent = true;
         lastError = null;
-        metadata = serverInfo.resourceTimerIsTransientError()
-            ? ResourceMetadata.newResourceMetadataTimeout()
-            : ResourceMetadata.newResourceMetadataDoesNotExist();
-        for (ResourceWatcher<T> watcher : watchers.keySet()) {
+
+        Status status;
+        if (respTimer == null) {
+          status = Status.NOT_FOUND.withDescription("Resource " + resource + " does not exist");
+          metadata = ResourceMetadata.newResourceMetadataDoesNotExist();
+        } else {
+          status = serverInfo.resourceTimerIsTransientError()
+              ? Status.UNAVAILABLE.withDescription(
+                  "Timed out waiting for resource " + resource + " from xDS server")
+              : Status.NOT_FOUND.withDescription(
+                  "Timed out waiting for resource " + resource + " from xDS server");
+          metadata = serverInfo.resourceTimerIsTransientError()
+              ? ResourceMetadata.newResourceMetadataTimeout()
+              : ResourceMetadata.newResourceMetadataDoesNotExist();
+        }
+
+        StatusOr<T> update = StatusOr.fromStatus(status);
+        for (Map.Entry<ResourceWatcher<T>, Executor> entry : watchers.entrySet()) {
           if (processingTracker != null) {
             processingTracker.startTask();
           }
-          watchers.get(watcher).execute(() -> {
+          entry.getValue().execute(() -> {
             try {
-              if (serverInfo.resourceTimerIsTransientError()) {
-                watcher.onError(Status.UNAVAILABLE.withDescription(
-                    "Timed out waiting for resource " + resource + " from xDS server"));
-              } else {
-                watcher.onResourceDoesNotExist(resource);
-              }
+              entry.getKey().onResourceChanged(update);
             } finally {
               if (processingTracker != null) {
                 processingTracker.onComplete();
@@ -918,13 +937,37 @@ public final class XdsClientImpl extends XdsClient implements ResourceStore {
           .withCause(error.getCause());
       this.lastError = errorAugmented;
 
-      for (ResourceWatcher<T> watcher : watchers.keySet()) {
+      if (data != null) {
+        // We have cached data, so this is an ambient error.
+        onAmbientError(errorAugmented, tracker);
+      } else {
+        // No data, this is a definitive resource error.
+        StatusOr<T> update = StatusOr.fromStatus(errorAugmented);
+        for (Map.Entry<ResourceWatcher<T>, Executor> entry : watchers.entrySet()) {
+          if (tracker != null) {
+            tracker.startTask();
+          }
+          entry.getValue().execute(() -> {
+            try {
+              entry.getKey().onResourceChanged(update);
+            } finally {
+              if (tracker != null) {
+                tracker.onComplete();
+              }
+            }
+          });
+        }
+      }
+    }
+
+    private void onAmbientError(Status error, @Nullable ProcessingTracker tracker) {
+      for (Map.Entry<ResourceWatcher<T>, Executor> entry : watchers.entrySet()) {
         if (tracker != null) {
           tracker.startTask();
         }
-        watchers.get(watcher).execute(() -> {
+        entry.getValue().execute(() -> {
           try {
-            watcher.onError(errorAugmented);
+            entry.getKey().onAmbientError(error);
           } finally {
             if (tracker != null) {
               tracker.onComplete();
@@ -938,10 +981,6 @@ public final class XdsClientImpl extends XdsClient implements ResourceStore {
       metadata = ResourceMetadata
           .newResourceMetadataNacked(metadata, rejectedVersion, rejectedTime, rejectedDetails,
               data != null);
-    }
-
-    private void notifyWatcher(ResourceWatcher<T> watcher, T update) {
-      watcher.onChanged(update);
     }
   }
 
@@ -982,33 +1021,54 @@ public final class XdsClientImpl extends XdsClient implements ResourceStore {
       cleanUpResourceTimers(cpcClosed);
 
       if (status.isOk()) {
-        return; // Not considered an error
+        return; // Not an error.
       }
 
-      metricReporter.reportServerFailure(1L, serverInfo.target());
+      if (shouldTryFallback) { // This indicates no response was received on the stream.
+        metricReporter.reportServerFailure(1L, serverInfo.target());
+      }
 
+      // Step 1: Determine if we even need to consider falling back.
+      // We only fall back if the stream failed AND we are missing at least one resource.
+      boolean anyWatcherIsMissingResource = false;
       Collection<String> authoritiesForClosedCpc = getActiveAuthorities(cpcClosed);
       for (Map<String, ResourceSubscriber<? extends ResourceUpdate>> subscriberMap :
           resourceSubscribers.values()) {
         for (ResourceSubscriber<? extends ResourceUpdate> subscriber : subscriberMap.values()) {
-          if (subscriber.hasResult() || !authoritiesForClosedCpc.contains(subscriber.authority)) {
-            continue;
+          if (authoritiesForClosedCpc.contains(subscriber.authority) && !subscriber.hasResult()) {
+            anyWatcherIsMissingResource = true;
+            break;
           }
+        }
+        if (anyWatcherIsMissingResource) {
+          break;
+        }
+      }
 
-          // try to fallback to lower priority control plane client
-          if (shouldTryFallback && manageControlPlaneClient(subscriber).didFallback) {
-            authoritiesForClosedCpc.remove(subscriber.authority);
-            if (authoritiesForClosedCpc.isEmpty()) {
-              return; // optimization: no need to continue once all authorities have done fallback
+      // Step 2: If fallback is possible and needed, attempt it for the watchers that need it.
+      if (shouldTryFallback && anyWatcherIsMissingResource) {
+        for (Map<String, ResourceSubscriber<? extends ResourceUpdate>> subscriberMap :
+            resourceSubscribers.values()) {
+          for (ResourceSubscriber<? extends ResourceUpdate> subscriber : subscriberMap.values()) {
+            if (!subscriber.hasResult() && authoritiesForClosedCpc.contains(subscriber.authority)) {
+              manageControlPlaneClient(subscriber);
             }
-            continue; // since we did fallback, don't consider it an error
           }
+        }
+      }
 
-          subscriber.onError(status, null);
+      // Step 3: Notify all affected watchers about the stream error.
+      // The subscriber's internal 'onError' will correctly delegate to the watcher's
+      // 'onAmbientError' or 'onResourceChanged' based on its current state (i.e. if it has data).
+      for (Map<String, ResourceSubscriber<? extends ResourceUpdate>> subscriberMap :
+          resourceSubscribers.values()) {
+        for (ResourceSubscriber<? extends ResourceUpdate> subscriber : subscriberMap.values()) {
+          if (authoritiesForClosedCpc.contains(subscriber.authority)) {
+            subscriber.onError(status, null);
+          }
         }
       }
     }
-
   }
 
   private static class CpcWithFallbackState {

--- a/xds/src/test/java/io/grpc/xds/CdsLoadBalancer2Test.java
+++ b/xds/src/test/java/io/grpc/xds/CdsLoadBalancer2Test.java
@@ -315,8 +315,10 @@ public class CdsLoadBalancer2Test {
     startXdsDepManager();
     verify(helper).updateBalancingState(
         eq(ConnectivityState.TRANSIENT_FAILURE), pickerCaptor.capture());
-    Status unavailable = Status.UNAVAILABLE.withDescription(
-        "CDS resource " + CLUSTER + " does not exist nodeID: " + NODE_ID);
+    String expectedDescription = "Error retrieving CDS resource " + CLUSTER + ": NOT_FOUND. "
+        + "Details: Timed out waiting for resource " + CLUSTER
+        + " from xDS server nodeID: " + NODE_ID;
+    Status unavailable = Status.UNAVAILABLE.withDescription(expectedDescription);
     assertPickerStatus(pickerCaptor.getValue(), unavailable);
     assertThat(childBalancers).isEmpty();
   }
@@ -372,8 +374,9 @@ public class CdsLoadBalancer2Test {
     controlPlaneService.setXdsConfig(ADS_TYPE_URL_CDS, ImmutableMap.of());
 
     assertThat(childBalancer.shutdown).isTrue();
-    Status unavailable = Status.UNAVAILABLE.withDescription(
-        "CDS resource " + CLUSTER + " does not exist nodeID: " + NODE_ID);
+    String expectedDescription = "Error retrieving CDS resource " + CLUSTER + ": NOT_FOUND. "
+        + "Details: Resource " + CLUSTER + " does not exist nodeID: " + NODE_ID;
+    Status unavailable = Status.UNAVAILABLE.withDescription(expectedDescription);
     verify(helper).updateBalancingState(
         eq(ConnectivityState.TRANSIENT_FAILURE), pickerCaptor.capture());
     assertPickerStatus(pickerCaptor.getValue(), unavailable);
@@ -583,8 +586,10 @@ public class CdsLoadBalancer2Test {
 
     verify(helper).updateBalancingState(
         eq(ConnectivityState.TRANSIENT_FAILURE), pickerCaptor.capture());
-    Status status = Status.UNAVAILABLE.withDescription(
-        "CDS resource " + cluster1 + " does not exist nodeID: " + NODE_ID);
+    String expectedDescription = "Error retrieving CDS resource " + cluster1 + ": NOT_FOUND. "
+        + "Details: Timed out waiting for resource " + cluster1 + " from xDS server nodeID: "
+        + NODE_ID;
+    Status status = Status.UNAVAILABLE.withDescription(expectedDescription);
     assertPickerStatus(pickerCaptor.getValue(), status);
     assertThat(childBalancers).isEmpty();
   }

--- a/xds/src/test/java/io/grpc/xds/ClusterResolverLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/ClusterResolverLoadBalancerTest.java
@@ -688,11 +688,10 @@ public class ClusterResolverLoadBalancerTest {
 
     verify(helper).updateBalancingState(
         eq(ConnectivityState.TRANSIENT_FAILURE), pickerCaptor.capture());
-    assertPicker(
-        pickerCaptor.getValue(),
-        Status.UNAVAILABLE.withDescription(
-            "CDS resource " + CLUSTER + " does not exist nodeID: node-id"),
-        null);
+    String expectedDescription = "Error retrieving CDS resource " + CLUSTER + ": NOT_FOUND. "
+        + "Details: Timed out waiting for resource " + CLUSTER + " from xDS server nodeID: node-id";
+    Status expectedError = Status.UNAVAILABLE.withDescription(expectedDescription);
+    assertPicker(pickerCaptor.getValue(), expectedError, null);
   }
 
   @Test
@@ -712,8 +711,10 @@ public class ClusterResolverLoadBalancerTest {
     assertThat(childBalancers).hasSize(0);  // no child LB policy created
     verify(helper).updateBalancingState(
         eq(ConnectivityState.TRANSIENT_FAILURE), pickerCaptor.capture());
-    Status expectedError = Status.UNAVAILABLE.withDescription(
-        "CDS resource " + CLUSTER + " does not exist nodeID: node-id");
+    String expectedDescription = "Error retrieving CDS resource " + CLUSTER + ": NOT_FOUND. "
+        + "Details: Timed out waiting for resource " + CLUSTER + " from xDS server nodeID: node-id";
+    Status expectedError = Status.UNAVAILABLE.withDescription(expectedDescription);
+    assertPicker(pickerCaptor.getValue(), expectedError, null);
     assertPicker(pickerCaptor.getValue(), expectedError, null);
   }
 
@@ -741,8 +742,9 @@ public class ClusterResolverLoadBalancerTest {
     controlPlaneService.setXdsConfig(ADS_TYPE_URL_CDS, ImmutableMap.of());
     verify(helper).updateBalancingState(
         eq(ConnectivityState.TRANSIENT_FAILURE), pickerCaptor.capture());
-    Status expectedError = Status.UNAVAILABLE.withDescription(
-        "CDS resource " + CLUSTER + " does not exist nodeID: node-id");
+    String expectedDescription = "Error retrieving CDS resource " + CLUSTER + ": NOT_FOUND. "
+        + "Details: Resource " + CLUSTER + " does not exist nodeID: node-id";
+    Status expectedError = Status.UNAVAILABLE.withDescription(expectedDescription);
     assertPicker(pickerCaptor.getValue(), expectedError, null);
     assertThat(childBalancer.shutdown).isTrue();
   }
@@ -756,8 +758,10 @@ public class ClusterResolverLoadBalancerTest {
     FakeLoadBalancer childBalancer = Iterables.getOnlyElement(childBalancers);
     assertThat(childBalancer.upstreamError).isNotNull();
     assertThat(childBalancer.upstreamError.getCode()).isEqualTo(Status.Code.UNAVAILABLE);
-    assertThat(childBalancer.upstreamError.getDescription())
-        .isEqualTo("EDS resource " + EDS_SERVICE_NAME + " does not exist nodeID: node-id");
+    String expectedDescription = "Error retrieving EDS resource " + EDS_SERVICE_NAME
+        + ": NOT_FOUND. Details: Timed out waiting for resource " + EDS_SERVICE_NAME
+        + " from xDS server nodeID: node-id";
+    assertThat(childBalancer.upstreamError.getDescription()).isEqualTo(expectedDescription);
     assertThat(childBalancer.shutdown).isFalse();
   }
 

--- a/xds/src/test/java/io/grpc/xds/GrpcBootstrapperImplTest.java
+++ b/xds/src/test/java/io/grpc/xds/GrpcBootstrapperImplTest.java
@@ -584,7 +584,8 @@ public class GrpcBootstrapperImplTest {
     ServerInfo serverInfo = Iterables.getOnlyElement(info.servers());
     assertThat(serverInfo.target()).isEqualTo(SERVER_URI);
     assertThat(serverInfo.implSpecificConfig()).isInstanceOf(InsecureChannelCredentials.class);
-    assertThat(serverInfo.ignoreResourceDeletion()).isFalse();
+    // okshiva: the changes introduced flakyness for the below assert
+    // assertThat(serverInfo.ignoreResourceDeletion()).isFalse();
   }
 
   @Test
@@ -606,7 +607,8 @@ public class GrpcBootstrapperImplTest {
     ServerInfo serverInfo = Iterables.getOnlyElement(info.servers());
     assertThat(serverInfo.target()).isEqualTo(SERVER_URI);
     assertThat(serverInfo.implSpecificConfig()).isInstanceOf(InsecureChannelCredentials.class);
-    assertThat(serverInfo.ignoreResourceDeletion()).isFalse();
+    // okshiva: the changes introduced flakyness for the below assert
+    // assertThat(serverInfo.ignoreResourceDeletion()).isFalse();
   }
 
   @Test

--- a/xds/src/test/java/io/grpc/xds/GrpcBootstrapperImplTest.java
+++ b/xds/src/test/java/io/grpc/xds/GrpcBootstrapperImplTest.java
@@ -584,8 +584,7 @@ public class GrpcBootstrapperImplTest {
     ServerInfo serverInfo = Iterables.getOnlyElement(info.servers());
     assertThat(serverInfo.target()).isEqualTo(SERVER_URI);
     assertThat(serverInfo.implSpecificConfig()).isInstanceOf(InsecureChannelCredentials.class);
-    // okshiva: the changes introduced flakyness for the below assert
-    // assertThat(serverInfo.ignoreResourceDeletion()).isFalse();
+    assertThat(serverInfo.ignoreResourceDeletion()).isFalse();
   }
 
   @Test
@@ -607,8 +606,7 @@ public class GrpcBootstrapperImplTest {
     ServerInfo serverInfo = Iterables.getOnlyElement(info.servers());
     assertThat(serverInfo.target()).isEqualTo(SERVER_URI);
     assertThat(serverInfo.implSpecificConfig()).isInstanceOf(InsecureChannelCredentials.class);
-    // okshiva: the changes introduced flakyness for the below assert
-    // assertThat(serverInfo.ignoreResourceDeletion()).isFalse();
+    assertThat(serverInfo.ignoreResourceDeletion()).isFalse();
   }
 
   @Test

--- a/xds/src/test/java/io/grpc/xds/GrpcXdsClientImplTestBase.java
+++ b/xds/src/test/java/io/grpc/xds/GrpcXdsClientImplTestBase.java
@@ -19,12 +19,14 @@ package io.grpc.xds;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -56,6 +58,7 @@ import io.grpc.ManagedChannel;
 import io.grpc.Server;
 import io.grpc.Status;
 import io.grpc.Status.Code;
+import io.grpc.StatusOr;
 import io.grpc.inprocess.InProcessChannelBuilder;
 import io.grpc.inprocess.InProcessServerBuilder;
 import io.grpc.internal.BackoffPolicy;
@@ -126,7 +129,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.ArgumentCaptor;
-import org.mockito.ArgumentMatchers;
 import org.mockito.Captor;
 import org.mockito.InOrder;
 import org.mockito.Mock;
@@ -251,15 +253,13 @@ public abstract class GrpcXdsClientImplTestBase {
   private Message lbEndpointZeroWeight;
   private Any testClusterLoadAssignment;
   @Captor
-  private ArgumentCaptor<LdsUpdate> ldsUpdateCaptor;
+  private ArgumentCaptor<StatusOr<LdsUpdate>> ldsUpdateCaptor;
   @Captor
-  private ArgumentCaptor<RdsUpdate> rdsUpdateCaptor;
+  private ArgumentCaptor<StatusOr<RdsUpdate>> rdsUpdateCaptor;
   @Captor
-  private ArgumentCaptor<CdsUpdate> cdsUpdateCaptor;
+  private ArgumentCaptor<StatusOr<CdsUpdate>> cdsUpdateCaptor;
   @Captor
-  private ArgumentCaptor<EdsUpdate> edsUpdateCaptor;
-  @Captor
-  private ArgumentCaptor<Status> errorCaptor;
+  private ArgumentCaptor<StatusOr<EdsUpdate>> edsUpdateCaptor;
 
   @Mock
   private BackoffPolicy.Provider backoffPolicyProvider;
@@ -683,7 +683,10 @@ public abstract class GrpcXdsClientImplTestBase {
     verifySubscribedResourcesMetadataSizes(1, 0, 0, 0);
     // Server failed to return subscribed resource within expected time window.
     fakeClock.forwardTime(XdsClientImpl.INITIAL_RESOURCE_FETCH_TIMEOUT_SEC, TimeUnit.SECONDS);
-    verify(ldsResourceWatcher).onResourceDoesNotExist(LDS_RESOURCE);
+    verify(ldsResourceWatcher).onResourceChanged(ldsUpdateCaptor.capture());
+    StatusOr<LdsUpdate> statusOrUpdate = ldsUpdateCaptor.getValue();
+    assertThat(statusOrUpdate.hasValue()).isFalse();
+    assertThat(statusOrUpdate.getStatus().getCode()).isEqualTo(Status.Code.NOT_FOUND);
     assertThat(fakeClock.getPendingTasks(LDS_RESOURCE_FETCH_TIMEOUT_TASK_FILTER)).isEmpty();
     verifyResourceMetadataDoesNotExist(LDS, LDS_RESOURCE);
     // Check metric data.
@@ -696,11 +699,11 @@ public abstract class GrpcXdsClientImplTestBase {
         "xdstp://unknown.example.com/envoy.config.listener.v3.Listener/listener1";
     xdsClient.watchXdsResource(XdsListenerResource.getInstance(), ldsResourceName,
         ldsResourceWatcher);
-    verify(ldsResourceWatcher).onError(errorCaptor.capture());
-    Status error = errorCaptor.getValue();
-    assertThat(error.getCode()).isEqualTo(Code.INVALID_ARGUMENT);
-    assertThat(error.getDescription()).isEqualTo(
-        "Wrong configuration: xds server does not exist for resource " + ldsResourceName);
+    verify(ldsResourceWatcher).onResourceChanged(argThat(statusOr ->
+        !statusOr.hasValue()
+            && statusOr.getStatus().getCode() == Status.Code.INVALID_ARGUMENT
+            && statusOr.getStatus().getDescription().equals(
+            "Wrong configuration: xds server does not exist for resource " + ldsResourceName)));
     assertThat(resourceDiscoveryCalls.poll()).isNull();
     xdsClient.cancelXdsResourceWatch(XdsListenerResource.getInstance(), ldsResourceName,
         ldsResourceWatcher);
@@ -713,13 +716,20 @@ public abstract class GrpcXdsClientImplTestBase {
         ldsResourceWatcher);
     DiscoveryRpcCall call = resourceDiscoveryCalls.poll();
     call.sendCompleted();
-    verify(ldsResourceWatcher).onError(errorCaptor.capture());
-    Status initialError = errorCaptor.getValue();
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<StatusOr<LdsUpdate>> errorCaptor =
+        ArgumentCaptor.forClass(StatusOr.class);
+    verify(ldsResourceWatcher, timeout(1000)).onResourceChanged(errorCaptor.capture());
+    StatusOr<LdsUpdate> initialError = errorCaptor.getValue();
+    assertThat(initialError.hasValue()).isFalse();
+
     xdsClient.watchXdsResource(XdsListenerResource.getInstance(), LDS_RESOURCE,
         ldsResourceWatcher2);
-    ArgumentCaptor<Status> secondErrorCaptor = ArgumentCaptor.forClass(Status.class);
-    verify(ldsResourceWatcher2).onError(secondErrorCaptor.capture());
-    Status cachedError = secondErrorCaptor.getValue();
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<StatusOr<LdsUpdate>> secondErrorCaptor =
+        ArgumentCaptor.forClass(StatusOr.class);
+    verify(ldsResourceWatcher2, timeout(1000)).onResourceChanged(secondErrorCaptor.capture());
+    StatusOr<LdsUpdate> cachedError = secondErrorCaptor.getValue();
 
     assertThat(cachedError).isEqualTo(initialError);
     assertThat(resourceDiscoveryCalls.poll()).isNull();
@@ -760,7 +770,7 @@ public abstract class GrpcXdsClientImplTestBase {
     verifySubscribedResourcesMetadataSizes(1, 0, 0, 0);
     // The response is NACKed with the same error message.
     call.verifyRequestNack(LDS, LDS_RESOURCE, "", "0000", NODE, errors);
-    verify(ldsResourceWatcher).onChanged(any(LdsUpdate.class));
+    verify(ldsResourceWatcher).onResourceChanged(any());
   }
 
   /**
@@ -928,8 +938,10 @@ public abstract class GrpcXdsClientImplTestBase {
     // Client sends an ACK LDS request.
     call.sendResponse(LDS, testListenerVhosts, VERSION_1, "0000");
     call.verifyRequest(LDS, LDS_RESOURCE, VERSION_1, "0000", NODE);
-    verify(ldsResourceWatcher).onChanged(ldsUpdateCaptor.capture());
-    verifyGoldenListenerVhosts(ldsUpdateCaptor.getValue());
+    verify(ldsResourceWatcher).onResourceChanged(ldsUpdateCaptor.capture());
+    StatusOr<LdsUpdate> statusOrUpdate = ldsUpdateCaptor.getValue();
+    assertThat(statusOrUpdate.hasValue()).isTrue();
+    verifyGoldenListenerVhosts(statusOrUpdate.getValue());
     assertThat(fakeClock.getPendingTasks(LDS_RESOURCE_FETCH_TIMEOUT_TASK_FILTER)).isEmpty();
     verifyResourceMetadataAcked(LDS, LDS_RESOURCE, testListenerVhosts, VERSION_1, TIME_INCREMENT);
     verifySubscribedResourcesMetadataSizes(1, 0, 0, 0);
@@ -943,8 +955,10 @@ public abstract class GrpcXdsClientImplTestBase {
     // Client sends an ACK LDS request.
     call.sendResponse(LDS, mf.buildWrappedResource(testListenerVhosts), VERSION_1, "0000");
     call.verifyRequest(LDS, LDS_RESOURCE, VERSION_1, "0000", NODE);
-    verify(ldsResourceWatcher).onChanged(ldsUpdateCaptor.capture());
-    verifyGoldenListenerVhosts(ldsUpdateCaptor.getValue());
+    verify(ldsResourceWatcher).onResourceChanged(ldsUpdateCaptor.capture());
+    StatusOr<LdsUpdate> statusOrUpdate = ldsUpdateCaptor.getValue();
+    assertThat(statusOrUpdate.hasValue()).isTrue();
+    verifyGoldenListenerVhosts(statusOrUpdate.getValue());
     assertThat(fakeClock.getPendingTasks(LDS_RESOURCE_FETCH_TIMEOUT_TASK_FILTER)).isEmpty();
     verifyResourceMetadataAcked(LDS, LDS_RESOURCE, testListenerVhosts, VERSION_1, TIME_INCREMENT);
     verifySubscribedResourcesMetadataSizes(1, 0, 0, 0);
@@ -962,8 +976,10 @@ public abstract class GrpcXdsClientImplTestBase {
     call.sendResponse(LDS, mf.buildWrappedResourceWithName(innerResource, LDS_RESOURCE), VERSION_1,
         "0000");
     call.verifyRequest(LDS, LDS_RESOURCE, VERSION_1, "0000", NODE);
-    verify(ldsResourceWatcher).onChanged(ldsUpdateCaptor.capture());
-    verifyGoldenListenerVhosts(ldsUpdateCaptor.getValue());
+    verify(ldsResourceWatcher).onResourceChanged(ldsUpdateCaptor.capture());
+    StatusOr<LdsUpdate> statusOrUpdate = ldsUpdateCaptor.getValue();
+    assertThat(statusOrUpdate.hasValue()).isTrue();
+    verifyGoldenListenerVhosts(statusOrUpdate.getValue());
     assertThat(fakeClock.getPendingTasks(LDS_RESOURCE_FETCH_TIMEOUT_TASK_FILTER)).isEmpty();
     verifyResourceMetadataAcked(LDS, LDS_RESOURCE, innerResource, VERSION_1, TIME_INCREMENT);
     verifySubscribedResourcesMetadataSizes(1, 0, 0, 0);
@@ -977,8 +993,10 @@ public abstract class GrpcXdsClientImplTestBase {
 
     // Client sends an ACK LDS request.
     call.verifyRequest(LDS, LDS_RESOURCE, VERSION_1, "0000", NODE);
-    verify(ldsResourceWatcher).onChanged(ldsUpdateCaptor.capture());
-    verifyGoldenListenerRds(ldsUpdateCaptor.getValue());
+    verify(ldsResourceWatcher).onResourceChanged(ldsUpdateCaptor.capture());
+    StatusOr<LdsUpdate> statusOrUpdate = ldsUpdateCaptor.getValue();
+    assertThat(statusOrUpdate.hasValue()).isTrue();
+    verifyGoldenListenerRds(statusOrUpdate.getValue());
     assertThat(fakeClock.getPendingTasks(LDS_RESOURCE_FETCH_TIMEOUT_TASK_FILTER)).isEmpty();
     verifyResourceMetadataAcked(LDS, LDS_RESOURCE, testListenerRds, VERSION_1, TIME_INCREMENT);
     verifySubscribedResourcesMetadataSizes(1, 0, 0, 0);
@@ -996,8 +1014,10 @@ public abstract class GrpcXdsClientImplTestBase {
 
     ResourceWatcher<LdsUpdate> watcher = mock(ResourceWatcher.class);
     xdsClient.watchXdsResource(XdsListenerResource.getInstance(), LDS_RESOURCE, watcher);
-    verify(watcher).onChanged(ldsUpdateCaptor.capture());
-    verifyGoldenListenerRds(ldsUpdateCaptor.getValue());
+    verify(watcher).onResourceChanged(ldsUpdateCaptor.capture());
+    StatusOr<LdsUpdate> statusOrUpdate = ldsUpdateCaptor.getValue();
+    assertThat(statusOrUpdate.hasValue()).isTrue();
+    verifyGoldenListenerRds(statusOrUpdate.getValue());
     call.verifyNoMoreRequest();
     verifyResourceMetadataAcked(LDS, LDS_RESOURCE, testListenerRds, VERSION_1, TIME_INCREMENT);
     verifySubscribedResourcesMetadataSizes(1, 0, 0, 0);
@@ -1009,11 +1029,17 @@ public abstract class GrpcXdsClientImplTestBase {
     DiscoveryRpcCall call = startResourceWatcher(XdsListenerResource.getInstance(), LDS_RESOURCE,
         ldsResourceWatcher);
     fakeClock.forwardTime(XdsClientImpl.INITIAL_RESOURCE_FETCH_TIMEOUT_SEC, TimeUnit.SECONDS);
-    verify(ldsResourceWatcher).onResourceDoesNotExist(LDS_RESOURCE);
+    verify(ldsResourceWatcher).onResourceChanged(ldsUpdateCaptor.capture());
+    StatusOr<LdsUpdate> statusOrUpdate = ldsUpdateCaptor.getValue();
+    assertThat(statusOrUpdate.hasValue()).isFalse();
+    assertThat(statusOrUpdate.getStatus().getCode()).isEqualTo(Status.Code.NOT_FOUND);
     // Add another watcher.
     ResourceWatcher<LdsUpdate> watcher = mock(ResourceWatcher.class);
     xdsClient.watchXdsResource(XdsListenerResource.getInstance(), LDS_RESOURCE, watcher);
-    verify(watcher).onResourceDoesNotExist(LDS_RESOURCE);
+    verify(watcher).onResourceChanged(ldsUpdateCaptor.capture());
+    StatusOr<LdsUpdate> statusOrUpdate1 = ldsUpdateCaptor.getValue();
+    assertThat(statusOrUpdate1.hasValue()).isFalse();
+    assertThat(statusOrUpdate1.getStatus().getCode()).isEqualTo(Status.Code.NOT_FOUND);
     call.verifyNoMoreRequest();
     verifyResourceMetadataDoesNotExist(LDS, LDS_RESOURCE);
     verifySubscribedResourcesMetadataSizes(1, 0, 0, 0);
@@ -1028,15 +1054,19 @@ public abstract class GrpcXdsClientImplTestBase {
     // Initial LDS response.
     call.sendResponse(LDS, testListenerVhosts, VERSION_1, "0000");
     call.verifyRequest(LDS, LDS_RESOURCE, VERSION_1, "0000", NODE);
-    verify(ldsResourceWatcher).onChanged(ldsUpdateCaptor.capture());
-    verifyGoldenListenerVhosts(ldsUpdateCaptor.getValue());
+    verify(ldsResourceWatcher).onResourceChanged(ldsUpdateCaptor.capture());
+    StatusOr<LdsUpdate> statusOrUpdate = ldsUpdateCaptor.getValue();
+    assertThat(statusOrUpdate.hasValue()).isTrue();
+    verifyGoldenListenerVhosts(statusOrUpdate.getValue());
     verifyResourceMetadataAcked(LDS, LDS_RESOURCE, testListenerVhosts, VERSION_1, TIME_INCREMENT);
 
     // Updated LDS response.
     call.sendResponse(LDS, testListenerRds, VERSION_2, "0001");
     call.verifyRequest(LDS, LDS_RESOURCE, VERSION_2, "0001", NODE);
-    verify(ldsResourceWatcher, times(2)).onChanged(ldsUpdateCaptor.capture());
-    verifyGoldenListenerRds(ldsUpdateCaptor.getValue());
+    verify(ldsResourceWatcher, times(2)).onResourceChanged(ldsUpdateCaptor.capture());
+    statusOrUpdate = ldsUpdateCaptor.getValue();
+    assertThat(statusOrUpdate.hasValue()).isTrue();
+    verifyGoldenListenerRds(statusOrUpdate.getValue());
     verifyResourceMetadataAcked(LDS, LDS_RESOURCE, testListenerRds, VERSION_2, TIME_INCREMENT * 2);
     verifySubscribedResourcesMetadataSizes(1, 0, 0, 0);
     assertThat(channelForCustomAuthority).isNull();
@@ -1052,8 +1082,10 @@ public abstract class GrpcXdsClientImplTestBase {
     // Initial LDS response.
     call.sendResponse(LDS, testListenerVhosts, VERSION_1, "0000");
     call.verifyRequest(LDS, LDS_RESOURCE, VERSION_1, "0000", NODE);
-    verify(ldsResourceWatcher).onChanged(ldsUpdateCaptor.capture());
-    verifyGoldenListenerVhosts(ldsUpdateCaptor.getValue());
+    verify(ldsResourceWatcher).onResourceChanged(ldsUpdateCaptor.capture());
+    StatusOr<LdsUpdate> statusOrUpdate = ldsUpdateCaptor.getValue();
+    assertThat(statusOrUpdate.hasValue()).isTrue();
+    verifyGoldenListenerVhosts(statusOrUpdate.getValue());
     verifyResourceMetadataAcked(LDS, LDS_RESOURCE, testListenerVhosts, VERSION_1, TIME_INCREMENT);
 
     xdsClient.watchXdsResource(XdsListenerResource.getInstance(),
@@ -1066,8 +1098,10 @@ public abstract class GrpcXdsClientImplTestBase {
         mf.buildRouteConfiguration("new", mf.buildOpaqueVirtualHosts(VHOST_SIZE))));
     call.sendResponse(LDS, testListenerVhosts2, VERSION_2, "0001");
     call.verifyRequest(LDS, LDS_RESOURCE, VERSION_2, "0001", NODE);
-    verify(ldsResourceWatcher).onChanged(ldsUpdateCaptor.capture());
-    verifyGoldenListenerVhosts(ldsUpdateCaptor.getValue());
+    verify(ldsResourceWatcher).onResourceChanged(ldsUpdateCaptor.capture());
+    statusOrUpdate = ldsUpdateCaptor.getValue();
+    assertThat(statusOrUpdate.hasValue()).isTrue();
+    verifyGoldenListenerVhosts(statusOrUpdate.getValue());
     verifyResourceMetadataAcked(LDS, LDS_RESOURCE, testListenerVhosts2, VERSION_2,
         TIME_INCREMENT * 2);
   }
@@ -1085,8 +1119,10 @@ public abstract class GrpcXdsClientImplTestBase {
         mf.buildRouteConfiguration("do not care", mf.buildOpaqueVirtualHosts(VHOST_SIZE))));
     call.sendResponse(LDS, testListenerVhosts, VERSION_1, "0000");
     call.verifyRequest(LDS, ldsResourceName, VERSION_1, "0000", NODE);
-    verify(ldsResourceWatcher).onChanged(ldsUpdateCaptor.capture());
-    verifyGoldenListenerVhosts(ldsUpdateCaptor.getValue());
+    verify(ldsResourceWatcher).onResourceChanged(ldsUpdateCaptor.capture());
+    StatusOr<LdsUpdate> statusOrUpdate = ldsUpdateCaptor.getValue();
+    assertThat(statusOrUpdate.hasValue()).isTrue();
+    verifyGoldenListenerVhosts(statusOrUpdate.getValue());
     verifyResourceMetadataAcked(
         LDS, ldsResourceName, testListenerVhosts, VERSION_1, TIME_INCREMENT);
   }
@@ -1103,8 +1139,10 @@ public abstract class GrpcXdsClientImplTestBase {
         mf.buildRouteConfiguration("do not care", mf.buildOpaqueVirtualHosts(VHOST_SIZE))));
     call.sendResponse(LDS, testListenerVhosts, VERSION_1, "0000");
     call.verifyRequest(LDS, ldsResourceName, VERSION_1, "0000", NODE);
-    verify(ldsResourceWatcher).onChanged(ldsUpdateCaptor.capture());
-    verifyGoldenListenerVhosts(ldsUpdateCaptor.getValue());
+    verify(ldsResourceWatcher).onResourceChanged(ldsUpdateCaptor.capture());
+    StatusOr<LdsUpdate> statusOrUpdate = ldsUpdateCaptor.getValue();
+    assertThat(statusOrUpdate.hasValue()).isTrue();
+    verifyGoldenListenerVhosts(statusOrUpdate.getValue());
     verifyResourceMetadataAcked(
         LDS, ldsResourceName, testListenerVhosts, VERSION_1, TIME_INCREMENT);
   }
@@ -1172,8 +1210,12 @@ public abstract class GrpcXdsClientImplTestBase {
         "xdstp://unknown.example.com/envoy.config.route.v3.RouteConfiguration/route1";
     xdsClient.watchXdsResource(XdsRouteConfigureResource.getInstance(), rdsResourceName,
         rdsResourceWatcher);
-    verify(rdsResourceWatcher).onError(errorCaptor.capture());
-    Status error = errorCaptor.getValue();
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<StatusOr<RdsUpdate>> rdsUpdateCaptor = ArgumentCaptor.forClass(StatusOr.class);
+    verify(rdsResourceWatcher).onResourceChanged(rdsUpdateCaptor.capture());
+    StatusOr<RdsUpdate> capturedUpdate = rdsUpdateCaptor.getValue();
+    assertThat(capturedUpdate.hasValue()).isFalse();
+    Status error = capturedUpdate.getStatus();
     assertThat(error.getCode()).isEqualTo(Code.INVALID_ARGUMENT);
     assertThat(error.getDescription()).isEqualTo(
         "Wrong configuration: xds server does not exist for resource " + rdsResourceName);
@@ -1207,8 +1249,12 @@ public abstract class GrpcXdsClientImplTestBase {
     String cdsResourceName = "xdstp://unknown.example.com/envoy.config.cluster.v3.Cluster/cluster1";
     xdsClient.watchXdsResource(XdsClusterResource.getInstance(), cdsResourceName,
         cdsResourceWatcher);
-    verify(cdsResourceWatcher).onError(errorCaptor.capture());
-    Status error = errorCaptor.getValue();
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<StatusOr<CdsUpdate>> cdsUpdateCaptor = ArgumentCaptor.forClass(StatusOr.class);
+    verify(cdsResourceWatcher).onResourceChanged(cdsUpdateCaptor.capture());
+    StatusOr<CdsUpdate> capturedUpdate = cdsUpdateCaptor.getValue();
+    assertThat(capturedUpdate.hasValue()).isFalse();
+    Status error = capturedUpdate.getStatus();
     assertThat(error.getCode()).isEqualTo(Code.INVALID_ARGUMENT);
     assertThat(error.getDescription()).isEqualTo(
         "Wrong configuration: xds server does not exist for resource " + cdsResourceName);
@@ -1247,8 +1293,12 @@ public abstract class GrpcXdsClientImplTestBase {
         "xdstp://unknown.example.com/envoy.config.endpoint.v3.ClusterLoadAssignment/cluster1";
     xdsClient.watchXdsResource(XdsEndpointResource.getInstance(),
         edsResourceName, edsResourceWatcher);
-    verify(edsResourceWatcher).onError(errorCaptor.capture());
-    Status error = errorCaptor.getValue();
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<StatusOr<EdsUpdate>> edsUpdateCaptor = ArgumentCaptor.forClass(StatusOr.class);
+    verify(edsResourceWatcher).onResourceChanged(edsUpdateCaptor.capture());
+    StatusOr<EdsUpdate> capturedUpdate = edsUpdateCaptor.getValue();
+    assertThat(capturedUpdate.hasValue()).isFalse();
+    Status error = capturedUpdate.getStatus();
     assertThat(error.getCode()).isEqualTo(Code.INVALID_ARGUMENT);
     assertThat(error.getDescription()).isEqualTo(
         "Wrong configuration: xds server does not exist for resource " + edsResourceName);
@@ -1297,11 +1347,13 @@ public abstract class GrpcXdsClientImplTestBase {
 
     // Client sends an ACK LDS request.
     call.verifyRequest(LDS, LDS_RESOURCE, VERSION_1, "0000", NODE);
-    verify(ldsResourceWatcher).onChanged(ldsUpdateCaptor.capture());
+    verify(ldsResourceWatcher).onResourceChanged(ldsUpdateCaptor.capture());
+    StatusOr<LdsUpdate> statusOrUpdate = ldsUpdateCaptor.getValue();
+    assertThat(statusOrUpdate.hasValue()).isTrue();
     verifyResourceMetadataAcked(LDS, LDS_RESOURCE, listener, VERSION_1, TIME_INCREMENT);
     verifySubscribedResourcesMetadataSizes(1, 0, 0, 0);
 
-    LdsUpdate ldsUpdate = ldsUpdateCaptor.getValue();
+    LdsUpdate ldsUpdate = statusOrUpdate.getValue();
     assertThat(ldsUpdate.httpConnectionManager().virtualHosts()).hasSize(2);
     assertThat(ldsUpdate.httpConnectionManager().httpFilterConfigs().get(0).name)
         .isEqualTo("envoy.fault");
@@ -1326,6 +1378,7 @@ public abstract class GrpcXdsClientImplTestBase {
   @Test
   public void ldsResourceDeleted() {
     Assume.assumeFalse(ignoreResourceDeletion());
+    InOrder inOrder = inOrder(ldsResourceWatcher);
 
     DiscoveryRpcCall call = startResourceWatcher(XdsListenerResource.getInstance(), LDS_RESOURCE,
         ldsResourceWatcher);
@@ -1334,15 +1387,20 @@ public abstract class GrpcXdsClientImplTestBase {
     // Initial LDS response.
     call.sendResponse(LDS, testListenerVhosts, VERSION_1, "0000");
     call.verifyRequest(LDS, LDS_RESOURCE, VERSION_1, "0000", NODE);
-    verify(ldsResourceWatcher).onChanged(ldsUpdateCaptor.capture());
-    verifyGoldenListenerVhosts(ldsUpdateCaptor.getValue());
+    inOrder.verify(ldsResourceWatcher).onResourceChanged(ldsUpdateCaptor.capture());
+    StatusOr<LdsUpdate> statusOrUpdate = ldsUpdateCaptor.getValue();
+    assertThat(statusOrUpdate.hasValue()).isTrue();
+    verifyGoldenListenerVhosts(statusOrUpdate.getValue());
     verifyResourceMetadataAcked(LDS, LDS_RESOURCE, testListenerVhosts, VERSION_1, TIME_INCREMENT);
     verifySubscribedResourcesMetadataSizes(1, 0, 0, 0);
 
     // Empty LDS response deletes the listener.
     call.sendResponse(LDS, Collections.<Any>emptyList(), VERSION_2, "0001");
     call.verifyRequest(LDS, LDS_RESOURCE, VERSION_2, "0001", NODE);
-    verify(ldsResourceWatcher).onResourceDoesNotExist(LDS_RESOURCE);
+    inOrder.verify(ldsResourceWatcher).onResourceChanged(ldsUpdateCaptor.capture());
+    StatusOr<LdsUpdate> statusOrUpdate1 = ldsUpdateCaptor.getValue();
+    assertThat(statusOrUpdate1.hasValue()).isFalse();
+    assertThat(statusOrUpdate1.getStatus().getCode()).isEqualTo(Status.Code.NOT_FOUND);
     verifyResourceMetadataDoesNotExist(LDS, LDS_RESOURCE);
     verifySubscribedResourcesMetadataSizes(1, 0, 0, 0);
   }
@@ -1362,8 +1420,8 @@ public abstract class GrpcXdsClientImplTestBase {
     // Initial LDS response.
     call.sendResponse(LDS, testListenerVhosts, VERSION_1, "0000");
     call.verifyRequest(LDS, LDS_RESOURCE, VERSION_1, "0000", NODE);
-    verify(ldsResourceWatcher).onChanged(ldsUpdateCaptor.capture());
-    verifyGoldenListenerVhosts(ldsUpdateCaptor.getValue());
+    verify(ldsResourceWatcher).onResourceChanged(ldsUpdateCaptor.capture());
+    verifyGoldenListenerVhosts(ldsUpdateCaptor.getValue().getValue());
     verifyResourceMetadataAcked(LDS, LDS_RESOURCE, testListenerVhosts, VERSION_1, TIME_INCREMENT);
     verifySubscribedResourcesMetadataSizes(1, 0, 0, 0);
 
@@ -1371,19 +1429,21 @@ public abstract class GrpcXdsClientImplTestBase {
     call.sendResponse(LDS, Collections.emptyList(), VERSION_2, "0001");
     call.verifyRequest(LDS, LDS_RESOURCE, VERSION_2, "0001", NODE);
     // The resource is still ACKED at VERSION_1 (no changes).
+    verify(ldsResourceWatcher).onAmbientError(
+        argThat(status -> status.getCode() == Status.Code.NOT_FOUND));
     verifyResourceMetadataAcked(LDS, LDS_RESOURCE, testListenerVhosts, VERSION_1, TIME_INCREMENT);
     verifySubscribedResourcesMetadataSizes(1, 0, 0, 0);
-    // onResourceDoesNotExist not called
-    verify(ldsResourceWatcher, never()).onResourceDoesNotExist(LDS_RESOURCE);
 
     // Next update is correct, and contains the listener again.
-    call.sendResponse(LDS, testListenerVhosts, VERSION_3, "0003");
+    Any updatedListener = Any.pack(mf.buildListenerWithApiListener(LDS_RESOURCE,
+        mf.buildRouteConfiguration("do not care", mf.buildOpaqueVirtualHosts(VHOST_SIZE + 1))));
+    call.sendResponse(LDS, updatedListener, VERSION_3, "0003");
     call.verifyRequest(LDS, LDS_RESOURCE, VERSION_3, "0003", NODE);
-    verify(ldsResourceWatcher).onChanged(ldsUpdateCaptor.capture());
-    verifyGoldenListenerVhosts(ldsUpdateCaptor.getValue());
+    verify(ldsResourceWatcher, times(2)).onResourceChanged(ldsUpdateCaptor.capture());
+    assertThat(ldsUpdateCaptor.getValue().getValue().httpConnectionManager().virtualHosts())
+        .hasSize(VHOST_SIZE + 1);
     // LDS is now ACKEd at VERSION_3.
-    verifyResourceMetadataAcked(LDS, LDS_RESOURCE, testListenerVhosts, VERSION_3,
-        TIME_INCREMENT * 3);
+    verifyResourceMetadataAcked(LDS, LDS_RESOURCE, updatedListener, VERSION_3, TIME_INCREMENT * 3);
     verifySubscribedResourcesMetadataSizes(1, 0, 0, 0);
     verifyNoMoreInteractions(ldsResourceWatcher);
   }
@@ -1405,9 +1465,12 @@ public abstract class GrpcXdsClientImplTestBase {
     verifySubscribedResourcesMetadataSizes(2, 0, 0, 0);
 
     fakeClock.forwardTime(XdsClientImpl.INITIAL_RESOURCE_FETCH_TIMEOUT_SEC, TimeUnit.SECONDS);
-    verify(ldsResourceWatcher).onResourceDoesNotExist(LDS_RESOURCE);
-    verify(watcher1).onResourceDoesNotExist(ldsResourceTwo);
-    verify(watcher2).onResourceDoesNotExist(ldsResourceTwo);
+    verify(ldsResourceWatcher).onResourceChanged(argThat(statusOr ->
+        !statusOr.hasValue() && statusOr.getStatus().getDescription().contains(LDS_RESOURCE)));
+    verify(watcher1).onResourceChanged(argThat(statusOr ->
+        !statusOr.hasValue() && statusOr.getStatus().getDescription().contains(ldsResourceTwo)));
+    verify(watcher2).onResourceChanged(argThat(statusOr ->
+        !statusOr.hasValue() && statusOr.getStatus().getDescription().contains(ldsResourceTwo)));
     verifyResourceMetadataDoesNotExist(LDS, LDS_RESOURCE);
     verifyResourceMetadataDoesNotExist(LDS, ldsResourceTwo);
     verifySubscribedResourcesMetadataSizes(2, 0, 0, 0);
@@ -1415,16 +1478,22 @@ public abstract class GrpcXdsClientImplTestBase {
     Any listenerTwo = Any.pack(mf.buildListenerWithApiListenerForRds(ldsResourceTwo, RDS_RESOURCE));
     call.sendResponse(LDS, ImmutableList.of(testListenerVhosts, listenerTwo), VERSION_1, "0000");
     // ResourceWatcher called with listenerVhosts.
-    verify(ldsResourceWatcher).onChanged(ldsUpdateCaptor.capture());
-    verifyGoldenListenerVhosts(ldsUpdateCaptor.getValue());
+    verify(ldsResourceWatcher, times(2)).onResourceChanged(ldsUpdateCaptor.capture());
+    StatusOr<LdsUpdate> statusOrUpdate = ldsUpdateCaptor.getValue();
+    assertThat(statusOrUpdate.hasValue()).isTrue();
+    verifyGoldenListenerVhosts(statusOrUpdate.getValue());
     // watcher1 called with listenerTwo.
-    verify(watcher1).onChanged(ldsUpdateCaptor.capture());
-    verifyGoldenListenerRds(ldsUpdateCaptor.getValue());
-    assertThat(ldsUpdateCaptor.getValue().httpConnectionManager().virtualHosts()).isNull();
+    verify(watcher1, times(2)).onResourceChanged(ldsUpdateCaptor.capture());
+    statusOrUpdate = ldsUpdateCaptor.getValue();
+    assertThat(statusOrUpdate.hasValue()).isTrue();
+    verifyGoldenListenerRds(statusOrUpdate.getValue());
+    assertThat(statusOrUpdate.getValue().httpConnectionManager().virtualHosts()).isNull();
     // watcher2 called with listenerTwo.
-    verify(watcher2).onChanged(ldsUpdateCaptor.capture());
-    verifyGoldenListenerRds(ldsUpdateCaptor.getValue());
-    assertThat(ldsUpdateCaptor.getValue().httpConnectionManager().virtualHosts()).isNull();
+    verify(watcher2, times(2)).onResourceChanged(ldsUpdateCaptor.capture());
+    statusOrUpdate = ldsUpdateCaptor.getValue();
+    assertThat(statusOrUpdate.hasValue()).isTrue();
+    verifyGoldenListenerRds(statusOrUpdate.getValue());
+    assertThat(statusOrUpdate.getValue().httpConnectionManager().virtualHosts()).isNull();
     // Metadata of both listeners is stored.
     verifyResourceMetadataAcked(LDS, LDS_RESOURCE, testListenerVhosts, VERSION_1, TIME_INCREMENT);
     verifyResourceMetadataAcked(LDS, ldsResourceTwo, listenerTwo, VERSION_1, TIME_INCREMENT);
@@ -1446,7 +1515,8 @@ public abstract class GrpcXdsClientImplTestBase {
     verifySubscribedResourcesMetadataSizes(0, 0, 1, 0);
     // Server failed to return subscribed resource within expected time window.
     fakeClock.forwardTime(XdsClientImpl.INITIAL_RESOURCE_FETCH_TIMEOUT_SEC, TimeUnit.SECONDS);
-    verify(rdsResourceWatcher).onResourceDoesNotExist(RDS_RESOURCE);
+    verify(rdsResourceWatcher).onResourceChanged(argThat(
+        arg -> !arg.hasValue() && arg.getStatus().getDescription().contains(RDS_RESOURCE)));
     assertThat(fakeClock.getPendingTasks(RDS_RESOURCE_FETCH_TIMEOUT_TASK_FILTER)).isEmpty();
     verifyResourceMetadataDoesNotExist(RDS, RDS_RESOURCE);
     verifySubscribedResourcesMetadataSizes(0, 0, 1, 0);
@@ -1487,7 +1557,7 @@ public abstract class GrpcXdsClientImplTestBase {
     verifySubscribedResourcesMetadataSizes(0, 0, 1, 0);
     // The response is NACKed with the same error message.
     call.verifyRequestNack(RDS, RDS_RESOURCE, "", "0000", NODE, errors);
-    verify(rdsResourceWatcher).onChanged(any(RdsUpdate.class));
+    verify(rdsResourceWatcher).onResourceChanged(any());
   }
 
   @Test
@@ -1495,6 +1565,7 @@ public abstract class GrpcXdsClientImplTestBase {
     DiscoveryRpcCall call = startResourceWatcher(XdsRouteConfigureResource.getInstance(),
         RDS_RESOURCE, rdsResourceWatcher);
     verifyResourceMetadataRequested(RDS, RDS_RESOURCE);
+    String expectedErrorDetail = "Sum of cluster weights should be above 0";
 
     io.envoyproxy.envoy.config.route.v3.RouteAction routeAction =
         io.envoyproxy.envoy.config.route.v3.RouteAction.newBuilder()
@@ -1528,11 +1599,14 @@ public abstract class GrpcXdsClientImplTestBase {
         "RDS response RouteConfiguration \'route-configuration.googleapis.com\' validation error: "
             + "RouteConfiguration contains invalid virtual host: Virtual host [do not care] "
             + "contains invalid route : Route [route-blade] contains invalid RouteAction: "
-            + "Sum of cluster weights should be above 0.");
+            + expectedErrorDetail);
     verifySubscribedResourcesMetadataSizes(0, 0, 1, 0);
     // The response is NACKed with the same error message.
     call.verifyRequestNack(RDS, RDS_RESOURCE, "", "0000", NODE, errors);
-    verify(rdsResourceWatcher, never()).onChanged(any(RdsUpdate.class));
+    verify(rdsResourceWatcher).onResourceChanged(argThat(
+        statusOr -> !statusOr.hasValue() && statusOr.getStatus().getDescription()
+            .contains(expectedErrorDetail)));
+    verify(rdsResourceWatcher, never()).onResourceChanged(argThat(StatusOr::hasValue));
   }
 
   /**
@@ -1614,8 +1688,10 @@ public abstract class GrpcXdsClientImplTestBase {
 
     // Client sends an ACK RDS request.
     call.verifyRequest(RDS, RDS_RESOURCE, VERSION_1, "0000", NODE);
-    verify(rdsResourceWatcher).onChanged(rdsUpdateCaptor.capture());
-    verifyGoldenRouteConfig(rdsUpdateCaptor.getValue());
+    verify(rdsResourceWatcher).onResourceChanged(rdsUpdateCaptor.capture());
+    StatusOr<RdsUpdate> statusOrUpdate = rdsUpdateCaptor.getValue();
+    assertThat(statusOrUpdate.hasValue()).isTrue();
+    verifyGoldenRouteConfig(statusOrUpdate.getValue());
     assertThat(fakeClock.getPendingTasks(RDS_RESOURCE_FETCH_TIMEOUT_TASK_FILTER)).isEmpty();
     verifyResourceMetadataAcked(RDS, RDS_RESOURCE, testRouteConfig, VERSION_1, TIME_INCREMENT);
     verifySubscribedResourcesMetadataSizes(0, 0, 1, 0);
@@ -1629,8 +1705,10 @@ public abstract class GrpcXdsClientImplTestBase {
 
     // Client sends an ACK RDS request.
     call.verifyRequest(RDS, RDS_RESOURCE, VERSION_1, "0000", NODE);
-    verify(rdsResourceWatcher).onChanged(rdsUpdateCaptor.capture());
-    verifyGoldenRouteConfig(rdsUpdateCaptor.getValue());
+    verify(rdsResourceWatcher).onResourceChanged(rdsUpdateCaptor.capture());
+    StatusOr<RdsUpdate> statusOrUpdate = rdsUpdateCaptor.getValue();
+    assertThat(statusOrUpdate.hasValue()).isTrue();
+    verifyGoldenRouteConfig(statusOrUpdate.getValue());
     assertThat(fakeClock.getPendingTasks(RDS_RESOURCE_FETCH_TIMEOUT_TASK_FILTER)).isEmpty();
     verifyResourceMetadataAcked(RDS, RDS_RESOURCE, testRouteConfig, VERSION_1, TIME_INCREMENT);
     verifySubscribedResourcesMetadataSizes(0, 0, 1, 0);
@@ -1648,8 +1726,10 @@ public abstract class GrpcXdsClientImplTestBase {
 
     ResourceWatcher<RdsUpdate> watcher = mock(ResourceWatcher.class);
     xdsClient.watchXdsResource(XdsRouteConfigureResource.getInstance(), RDS_RESOURCE, watcher);
-    verify(watcher).onChanged(rdsUpdateCaptor.capture());
-    verifyGoldenRouteConfig(rdsUpdateCaptor.getValue());
+    verify(watcher).onResourceChanged(rdsUpdateCaptor.capture());
+    StatusOr<RdsUpdate> statusOrUpdate = rdsUpdateCaptor.getValue();
+    assertThat(statusOrUpdate.hasValue()).isTrue();
+    verifyGoldenRouteConfig(statusOrUpdate.getValue());
     call.verifyNoMoreRequest();
     verifyResourceMetadataAcked(RDS, RDS_RESOURCE, testRouteConfig, VERSION_1, TIME_INCREMENT);
     verifySubscribedResourcesMetadataSizes(0, 0, 1, 0);
@@ -1661,11 +1741,15 @@ public abstract class GrpcXdsClientImplTestBase {
     DiscoveryRpcCall call = startResourceWatcher(XdsRouteConfigureResource.getInstance(),
         RDS_RESOURCE, rdsResourceWatcher);
     fakeClock.forwardTime(XdsClientImpl.INITIAL_RESOURCE_FETCH_TIMEOUT_SEC, TimeUnit.SECONDS);
-    verify(rdsResourceWatcher).onResourceDoesNotExist(RDS_RESOURCE);
+    verify(rdsResourceWatcher).onResourceChanged(argThat(statusOr ->
+        !statusOr.hasValue() && statusOr.getStatus().getDescription().contains(RDS_RESOURCE)
+            && statusOr.getStatus().getDescription().contains(RDS_RESOURCE)));
     // Add another watcher.
     ResourceWatcher<RdsUpdate> watcher = mock(ResourceWatcher.class);
     xdsClient.watchXdsResource(XdsRouteConfigureResource.getInstance(), RDS_RESOURCE, watcher);
-    verify(watcher).onResourceDoesNotExist(RDS_RESOURCE);
+    verify(watcher).onResourceChanged(argThat(statusOr ->
+        !statusOr.hasValue() && statusOr.getStatus().getDescription().contains(RDS_RESOURCE)
+            && statusOr.getStatus().getDescription().contains(RDS_RESOURCE)));
     call.verifyNoMoreRequest();
     verifyResourceMetadataDoesNotExist(RDS, RDS_RESOURCE);
     verifySubscribedResourcesMetadataSizes(0, 0, 1, 0);
@@ -1680,8 +1764,10 @@ public abstract class GrpcXdsClientImplTestBase {
     // Initial RDS response.
     call.sendResponse(RDS, testRouteConfig, VERSION_1, "0000");
     call.verifyRequest(RDS, RDS_RESOURCE, VERSION_1, "0000", NODE);
-    verify(rdsResourceWatcher).onChanged(rdsUpdateCaptor.capture());
-    verifyGoldenRouteConfig(rdsUpdateCaptor.getValue());
+    verify(rdsResourceWatcher).onResourceChanged(rdsUpdateCaptor.capture());
+    StatusOr<RdsUpdate> statusOrUpdate = rdsUpdateCaptor.getValue();
+    assertThat(statusOrUpdate.hasValue()).isTrue();
+    verifyGoldenRouteConfig(statusOrUpdate.getValue());
     verifyResourceMetadataAcked(RDS, RDS_RESOURCE, testRouteConfig, VERSION_1, TIME_INCREMENT);
 
     // Updated RDS response.
@@ -1691,8 +1777,10 @@ public abstract class GrpcXdsClientImplTestBase {
 
     // Client sends an ACK RDS request.
     call.verifyRequest(RDS, RDS_RESOURCE, VERSION_2, "0001", NODE);
-    verify(rdsResourceWatcher, times(2)).onChanged(rdsUpdateCaptor.capture());
-    assertThat(rdsUpdateCaptor.getValue().virtualHosts).hasSize(4);
+    verify(rdsResourceWatcher, times(2)).onResourceChanged(rdsUpdateCaptor.capture());
+    statusOrUpdate = rdsUpdateCaptor.getValue();
+    assertThat(statusOrUpdate.hasValue()).isTrue();
+    assertThat(statusOrUpdate.getValue().virtualHosts).hasSize(4);
     verifyResourceMetadataAcked(RDS, RDS_RESOURCE, routeConfigUpdated, VERSION_2,
         TIME_INCREMENT * 2);
   }
@@ -1739,15 +1827,19 @@ public abstract class GrpcXdsClientImplTestBase {
 
     DiscoveryRpcCall call = resourceDiscoveryCalls.poll();
     call.sendResponse(LDS, testListenerRds, VERSION_1, "0000");
-    verify(ldsResourceWatcher).onChanged(ldsUpdateCaptor.capture());
-    verifyGoldenListenerRds(ldsUpdateCaptor.getValue());
+    verify(ldsResourceWatcher).onResourceChanged(ldsUpdateCaptor.capture());
+    StatusOr<LdsUpdate> statusOrUpdate = ldsUpdateCaptor.getValue();
+    assertThat(statusOrUpdate.hasValue()).isTrue();
+    verifyGoldenListenerRds(statusOrUpdate.getValue());
     verifyResourceMetadataAcked(LDS, LDS_RESOURCE, testListenerRds, VERSION_1, TIME_INCREMENT);
     verifyResourceMetadataRequested(RDS, RDS_RESOURCE);
     verifySubscribedResourcesMetadataSizes(1, 0, 1, 0);
 
     call.sendResponse(RDS, testRouteConfig, VERSION_1, "0000");
-    verify(rdsResourceWatcher).onChanged(rdsUpdateCaptor.capture());
-    verifyGoldenRouteConfig(rdsUpdateCaptor.getValue());
+    verify(rdsResourceWatcher).onResourceChanged(rdsUpdateCaptor.capture());
+    StatusOr<RdsUpdate> statusOrUpdate1 = rdsUpdateCaptor.getValue();
+    assertThat(statusOrUpdate.hasValue()).isTrue();
+    verifyGoldenRouteConfig(statusOrUpdate1.getValue());
     verifyResourceMetadataAcked(LDS, LDS_RESOURCE, testListenerRds, VERSION_1, TIME_INCREMENT);
     verifyResourceMetadataAcked(RDS, RDS_RESOURCE, testRouteConfig, VERSION_1, TIME_INCREMENT * 2);
     verifySubscribedResourcesMetadataSizes(1, 0, 1, 0);
@@ -1757,8 +1849,10 @@ public abstract class GrpcXdsClientImplTestBase {
     // Note that this must work the same despite the ignore_resource_deletion feature is on.
     // This happens because the Listener is getting replaced, and not deleted.
     call.sendResponse(LDS, testListenerVhosts, VERSION_2, "0001");
-    verify(ldsResourceWatcher, times(2)).onChanged(ldsUpdateCaptor.capture());
-    verifyGoldenListenerVhosts(ldsUpdateCaptor.getValue());
+    verify(ldsResourceWatcher, times(2)).onResourceChanged(ldsUpdateCaptor.capture());
+    statusOrUpdate = ldsUpdateCaptor.getValue();
+    assertThat(statusOrUpdate.hasValue()).isTrue();
+    verifyGoldenListenerVhosts(statusOrUpdate.getValue());
     verifyNoMoreInteractions(rdsResourceWatcher);
     verifyResourceMetadataAcked(RDS, RDS_RESOURCE, testRouteConfig, VERSION_1, TIME_INCREMENT * 2);
     verifyResourceMetadataAcked(
@@ -1790,11 +1884,13 @@ public abstract class GrpcXdsClientImplTestBase {
     // referencing RDS_RESOURCE.
     DiscoveryRpcCall call = resourceDiscoveryCalls.poll();
     call.sendResponse(LDS, packedListener, VERSION_1, "0000");
-    verify(ldsResourceWatcher).onChanged(ldsUpdateCaptor.capture());
+    verify(ldsResourceWatcher).onResourceChanged(ldsUpdateCaptor.capture());
+    StatusOr<LdsUpdate> statusOrUpdate = ldsUpdateCaptor.getValue();
+    assertThat(statusOrUpdate.hasValue()).isTrue();
 
-    assertThat(ldsUpdateCaptor.getValue().listener().filterChains()).hasSize(1);
+    assertThat(statusOrUpdate.getValue().listener().filterChains()).hasSize(1);
     FilterChain parsedFilterChain = Iterables.getOnlyElement(
-        ldsUpdateCaptor.getValue().listener().filterChains());
+        statusOrUpdate.getValue().listener().filterChains());
     assertThat(parsedFilterChain.httpConnectionManager().rdsName()).isEqualTo(RDS_RESOURCE);
     verifyResourceMetadataAcked(LDS, LISTENER_RESOURCE, packedListener, VERSION_1, TIME_INCREMENT);
     verifyResourceMetadataRequested(RDS, RDS_RESOURCE);
@@ -1802,8 +1898,10 @@ public abstract class GrpcXdsClientImplTestBase {
 
     // Simulates receiving the requested RDS resource.
     call.sendResponse(RDS, testRouteConfig, VERSION_1, "0000");
-    verify(rdsResourceWatcher).onChanged(rdsUpdateCaptor.capture());
-    verifyGoldenRouteConfig(rdsUpdateCaptor.getValue());
+    verify(rdsResourceWatcher).onResourceChanged(rdsUpdateCaptor.capture());
+    StatusOr<RdsUpdate> statusOrUpdate1 = rdsUpdateCaptor.getValue();
+    assertThat(statusOrUpdate.hasValue()).isTrue();
+    verifyGoldenRouteConfig(statusOrUpdate1.getValue());
     verifyResourceMetadataAcked(RDS, RDS_RESOURCE, testRouteConfig, VERSION_1, TIME_INCREMENT * 2);
 
     // Simulates receiving an updated version of the requested LDS resource as a TCP listener
@@ -1821,12 +1919,15 @@ public abstract class GrpcXdsClientImplTestBase {
     packedListener =
         Any.pack(mf.buildListenerWithFilterChain(LISTENER_RESOURCE, 7000, "0.0.0.0", filterChain));
     call.sendResponse(LDS, packedListener, VERSION_2, "0001");
-    verify(ldsResourceWatcher, times(2)).onChanged(ldsUpdateCaptor.capture());
-    assertThat(ldsUpdateCaptor.getValue().listener().filterChains()).hasSize(1);
+    verify(ldsResourceWatcher, times(2)).onResourceChanged(ldsUpdateCaptor.capture());
+    statusOrUpdate = ldsUpdateCaptor.getValue();
+    assertThat(statusOrUpdate.hasValue()).isTrue();
+    assertThat(statusOrUpdate.getValue().listener().filterChains()).hasSize(1);
     parsedFilterChain = Iterables.getOnlyElement(
-        ldsUpdateCaptor.getValue().listener().filterChains());
+        statusOrUpdate.getValue().listener().filterChains());
     assertThat(parsedFilterChain.httpConnectionManager().virtualHosts()).hasSize(VHOST_SIZE);
-    verify(rdsResourceWatcher, never()).onResourceDoesNotExist(RDS_RESOURCE);
+    verify(rdsResourceWatcher, never()).onResourceChanged(argThat(statusOr ->
+        !statusOr.hasValue() && statusOr.getStatus().getDescription().equals(RDS_RESOURCE)));
     verifyResourceMetadataAcked(RDS, RDS_RESOURCE, testRouteConfig, VERSION_1, TIME_INCREMENT * 2);
     verifyResourceMetadataAcked(
         LDS, LISTENER_RESOURCE, packedListener, VERSION_2, TIME_INCREMENT * 3);
@@ -1851,16 +1952,25 @@ public abstract class GrpcXdsClientImplTestBase {
     verifySubscribedResourcesMetadataSizes(0, 0, 2, 0);
 
     fakeClock.forwardTime(XdsClientImpl.INITIAL_RESOURCE_FETCH_TIMEOUT_SEC, TimeUnit.SECONDS);
-    verify(rdsResourceWatcher).onResourceDoesNotExist(RDS_RESOURCE);
-    verify(watcher1).onResourceDoesNotExist(rdsResourceTwo);
-    verify(watcher2).onResourceDoesNotExist(rdsResourceTwo);
+    verify(rdsResourceWatcher).onResourceChanged(
+        argThat(statusOr -> !statusOr.hasValue()
+            && statusOr.getStatus().getCode() == Status.Code.NOT_FOUND));
+    verify(watcher1).onResourceChanged(
+        argThat(statusOr -> !statusOr.hasValue()
+            && statusOr.getStatus().getCode() == Status.Code.NOT_FOUND));
+    verify(watcher2).onResourceChanged(
+        argThat(statusOr -> !statusOr.hasValue()
+            && statusOr.getStatus().getCode() == Status.Code.NOT_FOUND));
     verifyResourceMetadataDoesNotExist(RDS, RDS_RESOURCE);
     verifyResourceMetadataDoesNotExist(RDS, rdsResourceTwo);
     verifySubscribedResourcesMetadataSizes(0, 0, 2, 0);
 
     call.sendResponse(RDS, testRouteConfig, VERSION_1, "0000");
-    verify(rdsResourceWatcher).onChanged(rdsUpdateCaptor.capture());
-    verifyGoldenRouteConfig(rdsUpdateCaptor.getValue());
+    ArgumentCaptor<StatusOr<RdsUpdate>> rdsUpdateCaptor = ArgumentCaptor.forClass(StatusOr.class);
+    verify(rdsResourceWatcher, times(2)).onResourceChanged(rdsUpdateCaptor.capture());
+    StatusOr<RdsUpdate> capturedUpdate1 = rdsUpdateCaptor.getAllValues().get(1);
+    assertThat(capturedUpdate1.hasValue()).isTrue();
+    verifyGoldenRouteConfig(capturedUpdate1.getValue());
     verifyNoMoreInteractions(watcher1, watcher2);
     verifyResourceMetadataAcked(RDS, RDS_RESOURCE, testRouteConfig, VERSION_1, TIME_INCREMENT);
     verifyResourceMetadataDoesNotExist(RDS, rdsResourceTwo);
@@ -1869,13 +1979,22 @@ public abstract class GrpcXdsClientImplTestBase {
     Any routeConfigTwo =
         Any.pack(mf.buildRouteConfiguration(rdsResourceTwo, mf.buildOpaqueVirtualHosts(4)));
     call.sendResponse(RDS, routeConfigTwo, VERSION_2, "0002");
-    verify(watcher1).onChanged(rdsUpdateCaptor.capture());
-    assertThat(rdsUpdateCaptor.getValue().virtualHosts).hasSize(4);
-    verify(watcher2).onChanged(rdsUpdateCaptor.capture());
-    assertThat(rdsUpdateCaptor.getValue().virtualHosts).hasSize(4);
+    ArgumentCaptor<StatusOr<RdsUpdate>> watcher1Captor =
+        ArgumentCaptor.forClass(StatusOr.class);
+    verify(watcher1, times(2)).onResourceChanged(watcher1Captor.capture());
+    StatusOr<RdsUpdate> capturedUpdate2 = watcher1Captor.getAllValues().get(1);
+    assertThat(capturedUpdate2.hasValue()).isTrue();
+    assertThat(capturedUpdate2.getValue().virtualHosts).hasSize(4);
+    ArgumentCaptor<StatusOr<RdsUpdate>> watcher2Captor =
+        ArgumentCaptor.forClass(StatusOr.class);
+    verify(watcher2, times(2)).onResourceChanged(watcher2Captor.capture());
+    StatusOr<RdsUpdate> capturedUpdate3 = watcher2Captor.getAllValues().get(1);
+    assertThat(capturedUpdate3.hasValue()).isTrue();
+    assertThat(capturedUpdate3.getValue().virtualHosts).hasSize(4);
     verifyNoMoreInteractions(rdsResourceWatcher);
     verifyResourceMetadataAcked(RDS, RDS_RESOURCE, testRouteConfig, VERSION_1, TIME_INCREMENT);
-    verifyResourceMetadataAcked(RDS, rdsResourceTwo, routeConfigTwo, VERSION_2, TIME_INCREMENT * 2);
+    verifyResourceMetadataAcked(RDS, rdsResourceTwo, routeConfigTwo, VERSION_2,
+        TIME_INCREMENT * 2);
     verifySubscribedResourcesMetadataSizes(0, 0, 2, 0);
   }
 
@@ -1898,7 +2017,8 @@ public abstract class GrpcXdsClientImplTestBase {
     verifySubscribedResourcesMetadataSizes(0, 1, 0, 0);
     // Server failed to return subscribed resource within expected time window.
     fakeClock.forwardTime(XdsClientImpl.INITIAL_RESOURCE_FETCH_TIMEOUT_SEC, TimeUnit.SECONDS);
-    verify(cdsResourceWatcher).onResourceDoesNotExist(CDS_RESOURCE);
+    verify(cdsResourceWatcher).onResourceChanged(argThat(
+        arg -> !arg.hasValue() && arg.getStatus().getDescription().contains(CDS_RESOURCE)));
     assertThat(fakeClock.getPendingTasks(CDS_RESOURCE_FETCH_TIMEOUT_TASK_FILTER)).isEmpty();
     verifyResourceMetadataDoesNotExist(CDS, CDS_RESOURCE);
     verifySubscribedResourcesMetadataSizes(0, 1, 0, 0);
@@ -1940,7 +2060,7 @@ public abstract class GrpcXdsClientImplTestBase {
     verifySubscribedResourcesMetadataSizes(0, 1, 0, 0);
     // The response is NACKed with the same error message.
     call.verifyRequestNack(CDS, CDS_RESOURCE, "", "0000", NODE, errors);
-    verify(cdsResourceWatcher).onChanged(any(CdsUpdate.class));
+    verify(cdsResourceWatcher).onResourceChanged(any());
   }
 
   /**
@@ -2130,8 +2250,10 @@ public abstract class GrpcXdsClientImplTestBase {
 
     // Client sent an ACK CDS request.
     call.verifyRequest(CDS, CDS_RESOURCE, VERSION_1, "0000", NODE);
-    verify(cdsResourceWatcher).onChanged(cdsUpdateCaptor.capture());
-    verifyGoldenClusterRoundRobin(cdsUpdateCaptor.getValue());
+    verify(cdsResourceWatcher).onResourceChanged(cdsUpdateCaptor.capture());
+    StatusOr<CdsUpdate> statusOrUpdate = cdsUpdateCaptor.getValue();
+    assertThat(statusOrUpdate.hasValue()).isTrue();
+    verifyGoldenClusterRoundRobin(statusOrUpdate.getValue());
     assertThat(fakeClock.getPendingTasks(CDS_RESOURCE_FETCH_TIMEOUT_TASK_FILTER)).isEmpty();
     verifyResourceMetadataAcked(CDS, CDS_RESOURCE, testClusterRoundRobin, VERSION_1,
         TIME_INCREMENT);
@@ -2146,8 +2268,10 @@ public abstract class GrpcXdsClientImplTestBase {
 
     // Client sent an ACK CDS request.
     call.verifyRequest(CDS, CDS_RESOURCE, VERSION_1, "0000", NODE);
-    verify(cdsResourceWatcher).onChanged(cdsUpdateCaptor.capture());
-    verifyGoldenClusterRoundRobin(cdsUpdateCaptor.getValue());
+    verify(cdsResourceWatcher).onResourceChanged(cdsUpdateCaptor.capture());
+    StatusOr<CdsUpdate> statusOrUpdate = cdsUpdateCaptor.getValue();
+    assertThat(statusOrUpdate.hasValue()).isTrue();
+    verifyGoldenClusterRoundRobin(statusOrUpdate.getValue());
     assertThat(fakeClock.getPendingTasks(CDS_RESOURCE_FETCH_TIMEOUT_TASK_FILTER)).isEmpty();
     verifyResourceMetadataAcked(CDS, CDS_RESOURCE, testClusterRoundRobin, VERSION_1,
         TIME_INCREMENT);
@@ -2167,8 +2291,10 @@ public abstract class GrpcXdsClientImplTestBase {
 
     // Client sent an ACK CDS request.
     call.verifyRequest(CDS, CDS_RESOURCE, VERSION_1, "0000", NODE);
-    verify(cdsResourceWatcher).onChanged(cdsUpdateCaptor.capture());
-    CdsUpdate cdsUpdate = cdsUpdateCaptor.getValue();
+    verify(cdsResourceWatcher).onResourceChanged(cdsUpdateCaptor.capture());
+    StatusOr<CdsUpdate> statusOrUpdate = cdsUpdateCaptor.getValue();
+    assertThat(statusOrUpdate.hasValue()).isTrue();
+    CdsUpdate cdsUpdate = statusOrUpdate.getValue();
     assertThat(cdsUpdate.clusterName()).isEqualTo(CDS_RESOURCE);
     assertThat(cdsUpdate.clusterType()).isEqualTo(ClusterType.EDS);
     assertThat(cdsUpdate.edsServiceName()).isNull();
@@ -2199,8 +2325,10 @@ public abstract class GrpcXdsClientImplTestBase {
 
     // Client sent an ACK CDS request.
     call.verifyRequest(CDS, CDS_RESOURCE, VERSION_1, "0000", NODE);
-    verify(cdsResourceWatcher).onChanged(cdsUpdateCaptor.capture());
-    CdsUpdate cdsUpdate = cdsUpdateCaptor.getValue();
+    verify(cdsResourceWatcher).onResourceChanged(cdsUpdateCaptor.capture());
+    StatusOr<CdsUpdate> statusOrUpdate = cdsUpdateCaptor.getValue();
+    assertThat(statusOrUpdate.hasValue()).isTrue();
+    CdsUpdate cdsUpdate = statusOrUpdate.getValue();
     assertThat(cdsUpdate.clusterName()).isEqualTo(CDS_RESOURCE);
     assertThat(cdsUpdate.clusterType()).isEqualTo(ClusterType.EDS);
     assertThat(cdsUpdate.edsServiceName()).isNull();
@@ -2230,8 +2358,10 @@ public abstract class GrpcXdsClientImplTestBase {
 
     // Client sent an ACK CDS request.
     call.verifyRequest(CDS, CDS_RESOURCE, VERSION_1, "0000", NODE);
-    verify(cdsResourceWatcher).onChanged(cdsUpdateCaptor.capture());
-    CdsUpdate cdsUpdate = cdsUpdateCaptor.getValue();
+    verify(cdsResourceWatcher).onResourceChanged(cdsUpdateCaptor.capture());
+    StatusOr<CdsUpdate> statusOrUpdate = cdsUpdateCaptor.getValue();
+    assertThat(statusOrUpdate.hasValue()).isTrue();
+    CdsUpdate cdsUpdate = statusOrUpdate.getValue();
     assertThat(cdsUpdate.clusterName()).isEqualTo(CDS_RESOURCE);
     assertThat(cdsUpdate.clusterType()).isEqualTo(ClusterType.AGGREGATE);
     LbConfig lbConfig = ServiceConfigUtil.unwrapLoadBalancingConfig(cdsUpdate.lbPolicyConfig());
@@ -2257,8 +2387,8 @@ public abstract class GrpcXdsClientImplTestBase {
     String errorMsg = "CDS response Cluster 'cluster.googleapis.com' validation error: "
         + "Cluster cluster.googleapis.com: aggregate ClusterConfig.clusters must not be empty";
     call.verifyRequestNack(CDS, CDS_RESOURCE, "", "0000", NODE, ImmutableList.of(errorMsg));
-    verify(cdsResourceWatcher).onError(errorCaptor.capture());
-    verifyStatusWithNodeId(errorCaptor.getValue(), Code.UNAVAILABLE, errorMsg);
+    verify(cdsResourceWatcher).onResourceChanged(cdsUpdateCaptor.capture());
+    verifyStatusWithNodeId(cdsUpdateCaptor.getValue().getStatus(), Code.UNAVAILABLE, errorMsg);
   }
 
   @Test
@@ -2272,8 +2402,10 @@ public abstract class GrpcXdsClientImplTestBase {
 
     // Client sent an ACK CDS request.
     call.verifyRequest(CDS, CDS_RESOURCE, VERSION_1, "0000", NODE);
-    verify(cdsResourceWatcher).onChanged(cdsUpdateCaptor.capture());
-    CdsUpdate cdsUpdate = cdsUpdateCaptor.getValue();
+    verify(cdsResourceWatcher).onResourceChanged(cdsUpdateCaptor.capture());
+    StatusOr<CdsUpdate> statusOrUpdate = cdsUpdateCaptor.getValue();
+    assertThat(statusOrUpdate.hasValue()).isTrue();
+    CdsUpdate cdsUpdate = statusOrUpdate.getValue();
     assertThat(cdsUpdate.clusterName()).isEqualTo(CDS_RESOURCE);
     assertThat(cdsUpdate.clusterType()).isEqualTo(ClusterType.EDS);
     assertThat(cdsUpdate.edsServiceName()).isNull();
@@ -2315,8 +2447,10 @@ public abstract class GrpcXdsClientImplTestBase {
     // Client sent an ACK CDS request.
     call.verifyRequest(CDS, CDS_RESOURCE, VERSION_1, "0000", NODE);
     verify(cdsResourceWatcher, times(1))
-        .onChanged(cdsUpdateCaptor.capture());
-    CdsUpdate cdsUpdate = cdsUpdateCaptor.getValue();
+        .onResourceChanged(cdsUpdateCaptor.capture());
+    StatusOr<CdsUpdate> statusOrUpdate = cdsUpdateCaptor.getValue();
+    assertThat(statusOrUpdate.hasValue()).isTrue();
+    CdsUpdate cdsUpdate = statusOrUpdate.getValue();
     CertificateProviderPluginInstance certificateProviderInstance =
         cdsUpdate.upstreamTlsContext().getCommonTlsContext().getCombinedValidationContext()
             .getDefaultValidationContext().getCaCertificateProviderInstance();
@@ -2350,8 +2484,10 @@ public abstract class GrpcXdsClientImplTestBase {
 
     // Client sent an ACK CDS request.
     call.verifyRequest(CDS, CDS_RESOURCE, VERSION_1, "0000", NODE);
-    verify(cdsResourceWatcher, times(1)).onChanged(cdsUpdateCaptor.capture());
-    CdsUpdate cdsUpdate = cdsUpdateCaptor.getValue();
+    verify(cdsResourceWatcher, times(1)).onResourceChanged(cdsUpdateCaptor.capture());
+    StatusOr<CdsUpdate> statusOrUpdate = cdsUpdateCaptor.getValue();
+    assertThat(statusOrUpdate.hasValue()).isTrue();
+    CdsUpdate cdsUpdate = statusOrUpdate.getValue();
     CertificateProviderPluginInstance certificateProviderInstance =
         cdsUpdate.upstreamTlsContext().getCommonTlsContext().getValidationContext()
             .getCaCertificateProviderInstance();
@@ -2383,8 +2519,8 @@ public abstract class GrpcXdsClientImplTestBase {
         + "ca_certificate_provider_instance or system_root_certs is required in "
         + "upstream-tls-context";
     call.verifyRequestNack(CDS, CDS_RESOURCE, "", "0000", NODE, ImmutableList.of(errorMsg));
-    verify(cdsResourceWatcher).onError(errorCaptor.capture());
-    verifyStatusWithNodeId(errorCaptor.getValue(), Code.UNAVAILABLE, errorMsg);
+    verify(cdsResourceWatcher).onResourceChanged(cdsUpdateCaptor.capture());
+    verifyStatusWithNodeId(cdsUpdateCaptor.getValue().getStatus(), Code.UNAVAILABLE, errorMsg);
   }
 
   /**
@@ -2425,8 +2561,10 @@ public abstract class GrpcXdsClientImplTestBase {
 
     // Client sent an ACK CDS request.
     call.verifyRequest(CDS, CDS_RESOURCE, VERSION_1, "0000", NODE);
-    verify(cdsResourceWatcher, times(1)).onChanged(cdsUpdateCaptor.capture());
-    CdsUpdate cdsUpdate = cdsUpdateCaptor.getValue();
+    verify(cdsResourceWatcher, times(1)).onResourceChanged(cdsUpdateCaptor.capture());
+    StatusOr<CdsUpdate> statusOrUpdate = cdsUpdateCaptor.getValue();
+    assertThat(statusOrUpdate.hasValue()).isTrue();
+    CdsUpdate cdsUpdate = statusOrUpdate.getValue();
 
     // The outlier detection config in CdsUpdate should match what we get from xDS.
     EnvoyServerProtoData.OutlierDetection outlierDetection = cdsUpdate.outlierDetection();
@@ -2486,8 +2624,8 @@ public abstract class GrpcXdsClientImplTestBase {
         + "io.grpc.xds.client.XdsResourceType$ResourceInvalidException: outlier_detection "
         + "max_ejection_percent is > 100";
     call.verifyRequestNack(CDS, CDS_RESOURCE, "", "0000", NODE, ImmutableList.of(errorMsg));
-    verify(cdsResourceWatcher).onError(errorCaptor.capture());
-    verifyStatusWithNodeId(errorCaptor.getValue(), Code.UNAVAILABLE, errorMsg);
+    verify(cdsResourceWatcher).onResourceChanged(cdsUpdateCaptor.capture());
+    verifyStatusWithNodeId(cdsUpdateCaptor.getValue().getStatus(), Code.UNAVAILABLE, errorMsg);
   }
 
   @Test(expected = ResourceInvalidException.class)
@@ -2581,8 +2719,8 @@ public abstract class GrpcXdsClientImplTestBase {
     String errorMsg = "CDS response Cluster 'cluster.googleapis.com' validation error: "
         + "transport-socket with name envoy.transport_sockets.bad not supported.";
     call.verifyRequestNack(CDS, CDS_RESOURCE, "", "0000", NODE, ImmutableList.of(errorMsg));
-    verify(cdsResourceWatcher).onError(errorCaptor.capture());
-    verifyStatusWithNodeId(errorCaptor.getValue(), Code.UNAVAILABLE, errorMsg);
+    verify(cdsResourceWatcher).onResourceChanged(cdsUpdateCaptor.capture());
+    verifyStatusWithNodeId(cdsUpdateCaptor.getValue().getStatus(), Code.UNAVAILABLE, errorMsg);
   }
 
   @Test
@@ -2624,8 +2762,10 @@ public abstract class GrpcXdsClientImplTestBase {
 
     ResourceWatcher<CdsUpdate> watcher = mock(ResourceWatcher.class);
     xdsClient.watchXdsResource(XdsClusterResource.getInstance(), CDS_RESOURCE, watcher);
-    verify(watcher).onChanged(cdsUpdateCaptor.capture());
-    verifyGoldenClusterRoundRobin(cdsUpdateCaptor.getValue());
+    verify(watcher).onResourceChanged(cdsUpdateCaptor.capture());
+    StatusOr<CdsUpdate> statusOrUpdate = cdsUpdateCaptor.getValue();
+    assertThat(statusOrUpdate.hasValue()).isTrue();
+    verifyGoldenClusterRoundRobin(statusOrUpdate.getValue());
     call.verifyNoMoreRequest();
     verifyResourceMetadataAcked(CDS, CDS_RESOURCE, testClusterRoundRobin, VERSION_1,
         TIME_INCREMENT);
@@ -2639,10 +2779,12 @@ public abstract class GrpcXdsClientImplTestBase {
     DiscoveryRpcCall call = startResourceWatcher(XdsClusterResource.getInstance(), CDS_RESOURCE,
         cdsResourceWatcher);
     fakeClock.forwardTime(XdsClientImpl.INITIAL_RESOURCE_FETCH_TIMEOUT_SEC, TimeUnit.SECONDS);
-    verify(cdsResourceWatcher).onResourceDoesNotExist(CDS_RESOURCE);
+    verify(cdsResourceWatcher).onResourceChanged(argThat(
+        arg -> !arg.hasValue() && arg.getStatus().getDescription().contains(CDS_RESOURCE)));
     ResourceWatcher<CdsUpdate> watcher = mock(ResourceWatcher.class);
     xdsClient.watchXdsResource(XdsClusterResource.getInstance(), CDS_RESOURCE, watcher);
-    verify(watcher).onResourceDoesNotExist(CDS_RESOURCE);
+    verify(watcher).onResourceChanged(argThat(
+        arg -> !arg.hasValue() && arg.getStatus().getDescription().contains(CDS_RESOURCE)));
     call.verifyNoMoreRequest();
     verifyResourceMetadataDoesNotExist(CDS, CDS_RESOURCE);
     verifySubscribedResourcesMetadataSizes(0, 1, 0, 0);
@@ -2662,8 +2804,10 @@ public abstract class GrpcXdsClientImplTestBase {
             null, null, false, null, null));
     call.sendResponse(CDS, clusterDns, VERSION_1, "0000");
     call.verifyRequest(CDS, CDS_RESOURCE, VERSION_1, "0000", NODE);
-    verify(cdsResourceWatcher).onChanged(cdsUpdateCaptor.capture());
-    CdsUpdate cdsUpdate = cdsUpdateCaptor.getValue();
+    verify(cdsResourceWatcher).onResourceChanged(cdsUpdateCaptor.capture());
+    StatusOr<CdsUpdate> statusOrUpdate = cdsUpdateCaptor.getValue();
+    assertThat(statusOrUpdate.hasValue()).isTrue();
+    CdsUpdate cdsUpdate = statusOrUpdate.getValue();
     assertThat(cdsUpdate.clusterName()).isEqualTo(CDS_RESOURCE);
     assertThat(cdsUpdate.clusterType()).isEqualTo(ClusterType.LOGICAL_DNS);
     assertThat(cdsUpdate.dnsHostName()).isEqualTo(dnsHostAddr + ":" + dnsHostPort);
@@ -2685,8 +2829,10 @@ public abstract class GrpcXdsClientImplTestBase {
         ));
     call.sendResponse(CDS, clusterEds, VERSION_2, "0001");
     call.verifyRequest(CDS, CDS_RESOURCE, VERSION_2, "0001", NODE);
-    verify(cdsResourceWatcher, times(2)).onChanged(cdsUpdateCaptor.capture());
-    cdsUpdate = cdsUpdateCaptor.getValue();
+    verify(cdsResourceWatcher, times(2)).onResourceChanged(cdsUpdateCaptor.capture());
+    statusOrUpdate = cdsUpdateCaptor.getValue();
+    assertThat(statusOrUpdate.hasValue()).isTrue();
+    cdsUpdate = statusOrUpdate.getValue();
     assertThat(cdsUpdate.clusterName()).isEqualTo(CDS_RESOURCE);
     assertThat(cdsUpdate.clusterType()).isEqualTo(ClusterType.EDS);
     assertThat(cdsUpdate.edsServiceName()).isEqualTo(edsService);
@@ -2727,27 +2873,27 @@ public abstract class GrpcXdsClientImplTestBase {
 
     // Configure with round robin, the update should be sent to the watcher.
     call.sendResponse(CDS, roundRobinConfig, VERSION_2, "0001");
-    verify(cdsResourceWatcher, times(1)).onChanged(isA(CdsUpdate.class));
+    verify(cdsResourceWatcher, times(1)).onResourceChanged(argThat(StatusOr::hasValue));
 
     // Second update is identical, watcher should not get an additional update.
     call.sendResponse(CDS, roundRobinConfig, VERSION_2, "0002");
-    verify(cdsResourceWatcher, times(1)).onChanged(isA(CdsUpdate.class));
+    verify(cdsResourceWatcher, times(1)).onResourceChanged(any());
 
     // Now we switch to ring hash so the watcher should be notified.
     call.sendResponse(CDS, ringHashConfig, VERSION_2, "0003");
-    verify(cdsResourceWatcher, times(2)).onChanged(isA(CdsUpdate.class));
+    verify(cdsResourceWatcher, times(2)).onResourceChanged(argThat(StatusOr::hasValue));
 
     // Second update to ring hash should not result in watcher being notified.
     call.sendResponse(CDS, ringHashConfig, VERSION_2, "0004");
-    verify(cdsResourceWatcher, times(2)).onChanged(isA(CdsUpdate.class));
+    verify(cdsResourceWatcher, times(2)).onResourceChanged(any());
 
     // Now we switch to least request so the watcher should be notified.
     call.sendResponse(CDS, leastRequestConfig, VERSION_2, "0005");
-    verify(cdsResourceWatcher, times(3)).onChanged(isA(CdsUpdate.class));
+    verify(cdsResourceWatcher, times(3)).onResourceChanged(argThat(StatusOr::hasValue));
 
     // Second update to least request should not result in watcher being notified.
     call.sendResponse(CDS, leastRequestConfig, VERSION_2, "0006");
-    verify(cdsResourceWatcher, times(3)).onChanged(isA(CdsUpdate.class));
+    verify(cdsResourceWatcher, times(3)).onResourceChanged(any());
   }
 
   @Test
@@ -2761,8 +2907,10 @@ public abstract class GrpcXdsClientImplTestBase {
     // Initial CDS response.
     call.sendResponse(CDS, testClusterRoundRobin, VERSION_1, "0000");
     call.verifyRequest(CDS, CDS_RESOURCE, VERSION_1, "0000", NODE);
-    verify(cdsResourceWatcher).onChanged(cdsUpdateCaptor.capture());
-    verifyGoldenClusterRoundRobin(cdsUpdateCaptor.getValue());
+    verify(cdsResourceWatcher).onResourceChanged(cdsUpdateCaptor.capture());
+    StatusOr<CdsUpdate> statusOrUpdate = cdsUpdateCaptor.getValue();
+    assertThat(statusOrUpdate.hasValue()).isTrue();
+    verifyGoldenClusterRoundRobin(statusOrUpdate.getValue());
     verifyResourceMetadataAcked(CDS, CDS_RESOURCE, testClusterRoundRobin, VERSION_1,
         TIME_INCREMENT);
     verifySubscribedResourcesMetadataSizes(0, 1, 0, 0);
@@ -2770,7 +2918,8 @@ public abstract class GrpcXdsClientImplTestBase {
     // Empty CDS response deletes the cluster.
     call.sendResponse(CDS, Collections.<Any>emptyList(), VERSION_2, "0001");
     call.verifyRequest(CDS, CDS_RESOURCE, VERSION_2, "0001", NODE);
-    verify(cdsResourceWatcher).onResourceDoesNotExist(CDS_RESOURCE);
+    verify(cdsResourceWatcher).onResourceChanged(argThat(
+        arg -> !arg.hasValue() && arg.getStatus().getDescription().contains(CDS_RESOURCE)));
     verifyResourceMetadataDoesNotExist(CDS, CDS_RESOURCE);
     verifySubscribedResourcesMetadataSizes(0, 1, 0, 0);
   }
@@ -2790,8 +2939,10 @@ public abstract class GrpcXdsClientImplTestBase {
     // Initial CDS response.
     call.sendResponse(CDS, testClusterRoundRobin, VERSION_1, "0000");
     call.verifyRequest(CDS, CDS_RESOURCE, VERSION_1, "0000", NODE);
-    verify(cdsResourceWatcher).onChanged(cdsUpdateCaptor.capture());
-    verifyGoldenClusterRoundRobin(cdsUpdateCaptor.getValue());
+    verify(cdsResourceWatcher).onResourceChanged(cdsUpdateCaptor.capture());
+    StatusOr<CdsUpdate> statusOrUpdate = cdsUpdateCaptor.getValue();
+    assertThat(statusOrUpdate.hasValue()).isTrue();
+    verifyGoldenClusterRoundRobin(statusOrUpdate.getValue());
     verifyResourceMetadataAcked(CDS, CDS_RESOURCE, testClusterRoundRobin, VERSION_1,
         TIME_INCREMENT);
     verifySubscribedResourcesMetadataSizes(0, 1, 0, 0);
@@ -2805,13 +2956,16 @@ public abstract class GrpcXdsClientImplTestBase {
         TIME_INCREMENT);
     verifySubscribedResourcesMetadataSizes(0, 1, 0, 0);
     // onResourceDoesNotExist must not be called.
-    verify(ldsResourceWatcher, never()).onResourceDoesNotExist(CDS_RESOURCE);
+    verify(ldsResourceWatcher, never()).onResourceChanged(argThat(
+        arg -> !arg.hasValue() && arg.getStatus().getDescription().contains(CDS_RESOURCE)));
 
     // Next update is correct, and contains the cluster again.
     call.sendResponse(CDS, testClusterRoundRobin, VERSION_3, "0003");
     call.verifyRequest(CDS, CDS_RESOURCE, VERSION_3, "0003", NODE);
-    verify(cdsResourceWatcher).onChanged(cdsUpdateCaptor.capture());
-    verifyGoldenClusterRoundRobin(cdsUpdateCaptor.getValue());
+    verify(cdsResourceWatcher).onResourceChanged(cdsUpdateCaptor.capture());
+    statusOrUpdate = cdsUpdateCaptor.getValue();
+    assertThat(statusOrUpdate.hasValue()).isTrue();
+    verifyGoldenClusterRoundRobin(statusOrUpdate.getValue());
     verifyResourceMetadataAcked(CDS, CDS_RESOURCE, testClusterRoundRobin, VERSION_3,
         TIME_INCREMENT * 3);
     verifySubscribedResourcesMetadataSizes(0, 1, 0, 0);
@@ -2834,9 +2988,12 @@ public abstract class GrpcXdsClientImplTestBase {
     verifySubscribedResourcesMetadataSizes(0, 2, 0, 0);
 
     fakeClock.forwardTime(XdsClientImpl.INITIAL_RESOURCE_FETCH_TIMEOUT_SEC, TimeUnit.SECONDS);
-    verify(cdsResourceWatcher).onResourceDoesNotExist(CDS_RESOURCE);
-    verify(watcher1).onResourceDoesNotExist(cdsResourceTwo);
-    verify(watcher2).onResourceDoesNotExist(cdsResourceTwo);
+    verify(cdsResourceWatcher).onResourceChanged(argThat(statusOr ->
+        statusOr.getStatus().getDescription().contains(CDS_RESOURCE)));
+    verify(watcher1).onResourceChanged(argThat(statusOr ->
+        statusOr.getStatus().getDescription().contains(cdsResourceTwo)));
+    verify(watcher2).onResourceChanged(argThat(statusOr ->
+        statusOr.getStatus().getDescription().contains(cdsResourceTwo)));
     verifyResourceMetadataDoesNotExist(CDS, CDS_RESOURCE);
     verifyResourceMetadataDoesNotExist(CDS, cdsResourceTwo);
     verifySubscribedResourcesMetadataSizes(0, 2, 0, 0);
@@ -2850,45 +3007,54 @@ public abstract class GrpcXdsClientImplTestBase {
         Any.pack(mf.buildEdsCluster(cdsResourceTwo, edsService, "round_robin", null, null, true,
             null, "envoy.transport_sockets.tls", null, null)));
     call.sendResponse(CDS, clusters, VERSION_1, "0000");
-    verify(cdsResourceWatcher).onChanged(cdsUpdateCaptor.capture());
-    CdsUpdate cdsUpdate = cdsUpdateCaptor.getValue();
-    assertThat(cdsUpdate.clusterName()).isEqualTo(CDS_RESOURCE);
-    assertThat(cdsUpdate.clusterType()).isEqualTo(ClusterType.LOGICAL_DNS);
-    assertThat(cdsUpdate.dnsHostName()).isEqualTo(dnsHostAddr + ":" + dnsHostPort);
-    LbConfig lbConfig = ServiceConfigUtil.unwrapLoadBalancingConfig(cdsUpdate.lbPolicyConfig());
+    ArgumentCaptor<StatusOr<CdsUpdate>> cdsUpdateCaptor = ArgumentCaptor.forClass(StatusOr.class);
+    verify(cdsResourceWatcher, times(2)).onResourceChanged(cdsUpdateCaptor.capture());
+    StatusOr<CdsUpdate> capturedUpdate1 = cdsUpdateCaptor.getAllValues().get(1);
+    assertThat(capturedUpdate1.hasValue()).isTrue();
+    CdsUpdate cdsUpdate1 = capturedUpdate1.getValue();
+    assertThat(cdsUpdate1.clusterName()).isEqualTo(CDS_RESOURCE);
+    assertThat(cdsUpdate1.clusterType()).isEqualTo(ClusterType.LOGICAL_DNS);
+    assertThat(cdsUpdate1.dnsHostName()).isEqualTo(dnsHostAddr + ":" + dnsHostPort);
+    LbConfig lbConfig = ServiceConfigUtil.unwrapLoadBalancingConfig(cdsUpdate1.lbPolicyConfig());
     assertThat(lbConfig.getPolicyName()).isEqualTo("wrr_locality_experimental");
     List<LbConfig> childConfigs = ServiceConfigUtil.unwrapLoadBalancingConfigList(
         JsonUtil.getListOfObjects(lbConfig.getRawConfigValue(), "childPolicy"));
     assertThat(childConfigs.get(0).getPolicyName()).isEqualTo("round_robin");
-    assertThat(cdsUpdate.lrsServerInfo()).isNull();
-    assertThat(cdsUpdate.maxConcurrentRequests()).isNull();
-    assertThat(cdsUpdate.upstreamTlsContext()).isNull();
-    verify(watcher1).onChanged(cdsUpdateCaptor.capture());
-    cdsUpdate = cdsUpdateCaptor.getValue();
-    assertThat(cdsUpdate.clusterName()).isEqualTo(cdsResourceTwo);
-    assertThat(cdsUpdate.clusterType()).isEqualTo(ClusterType.EDS);
-    assertThat(cdsUpdate.edsServiceName()).isEqualTo(edsService);
-    lbConfig = ServiceConfigUtil.unwrapLoadBalancingConfig(cdsUpdate.lbPolicyConfig());
+    assertThat(cdsUpdate1.lrsServerInfo()).isNull();
+    assertThat(cdsUpdate1.maxConcurrentRequests()).isNull();
+    assertThat(cdsUpdate1.upstreamTlsContext()).isNull();
+    ArgumentCaptor<StatusOr<CdsUpdate>> watcher1Captor = ArgumentCaptor.forClass(StatusOr.class);
+    verify(watcher1, times(2)).onResourceChanged(watcher1Captor.capture());
+    StatusOr<CdsUpdate> capturedUpdate2 = watcher1Captor.getAllValues().get(1);
+    assertThat(capturedUpdate2.hasValue()).isTrue();
+    CdsUpdate cdsUpdate2 = capturedUpdate2.getValue();
+    assertThat(cdsUpdate2.clusterName()).isEqualTo(cdsResourceTwo);
+    assertThat(cdsUpdate2.clusterType()).isEqualTo(ClusterType.EDS);
+    assertThat(cdsUpdate2.edsServiceName()).isEqualTo(edsService);
+    lbConfig = ServiceConfigUtil.unwrapLoadBalancingConfig(cdsUpdate2.lbPolicyConfig());
     assertThat(lbConfig.getPolicyName()).isEqualTo("wrr_locality_experimental");
     childConfigs = ServiceConfigUtil.unwrapLoadBalancingConfigList(
         JsonUtil.getListOfObjects(lbConfig.getRawConfigValue(), "childPolicy"));
     assertThat(childConfigs.get(0).getPolicyName()).isEqualTo("round_robin");
-    assertThat(cdsUpdate.lrsServerInfo()).isEqualTo(xdsServerInfo);
-    assertThat(cdsUpdate.maxConcurrentRequests()).isNull();
-    assertThat(cdsUpdate.upstreamTlsContext()).isNull();
-    verify(watcher2).onChanged(cdsUpdateCaptor.capture());
-    cdsUpdate = cdsUpdateCaptor.getValue();
-    assertThat(cdsUpdate.clusterName()).isEqualTo(cdsResourceTwo);
-    assertThat(cdsUpdate.clusterType()).isEqualTo(ClusterType.EDS);
-    assertThat(cdsUpdate.edsServiceName()).isEqualTo(edsService);
-    lbConfig = ServiceConfigUtil.unwrapLoadBalancingConfig(cdsUpdate.lbPolicyConfig());
+    assertThat(cdsUpdate2.lrsServerInfo()).isEqualTo(xdsServerInfo);
+    assertThat(cdsUpdate2.maxConcurrentRequests()).isNull();
+    assertThat(cdsUpdate2.upstreamTlsContext()).isNull();
+    ArgumentCaptor<StatusOr<CdsUpdate>> watcher2Captor = ArgumentCaptor.forClass(StatusOr.class);
+    verify(watcher2, times(2)).onResourceChanged(watcher2Captor.capture());
+    StatusOr<CdsUpdate> capturedUpdate3 = watcher2Captor.getAllValues().get(1);
+    assertThat(capturedUpdate3.hasValue()).isTrue();
+    CdsUpdate cdsUpdate3 = capturedUpdate3.getValue();
+    assertThat(cdsUpdate3.clusterName()).isEqualTo(cdsResourceTwo);
+    assertThat(cdsUpdate3.clusterType()).isEqualTo(ClusterType.EDS);
+    assertThat(cdsUpdate3.edsServiceName()).isEqualTo(edsService);
+    lbConfig = ServiceConfigUtil.unwrapLoadBalancingConfig(cdsUpdate3.lbPolicyConfig());
     assertThat(lbConfig.getPolicyName()).isEqualTo("wrr_locality_experimental");
     childConfigs = ServiceConfigUtil.unwrapLoadBalancingConfigList(
         JsonUtil.getListOfObjects(lbConfig.getRawConfigValue(), "childPolicy"));
     assertThat(childConfigs.get(0).getPolicyName()).isEqualTo("round_robin");
-    assertThat(cdsUpdate.lrsServerInfo()).isEqualTo(xdsServerInfo);
-    assertThat(cdsUpdate.maxConcurrentRequests()).isNull();
-    assertThat(cdsUpdate.upstreamTlsContext()).isNull();
+    assertThat(cdsUpdate3.lrsServerInfo()).isEqualTo(xdsServerInfo);
+    assertThat(cdsUpdate3.maxConcurrentRequests()).isNull();
+    assertThat(cdsUpdate3.upstreamTlsContext()).isNull();
     // Metadata of both clusters is stored.
     verifyResourceMetadataAcked(CDS, CDS_RESOURCE, clusters.get(0), VERSION_1, TIME_INCREMENT);
     verifyResourceMetadataAcked(CDS, cdsResourceTwo, clusters.get(1), VERSION_1, TIME_INCREMENT);
@@ -2912,7 +3078,8 @@ public abstract class GrpcXdsClientImplTestBase {
     verifySubscribedResourcesMetadataSizes(0, 0, 0, 1);
     // Server failed to return subscribed resource within expected time window.
     fakeClock.forwardTime(XdsClientImpl.INITIAL_RESOURCE_FETCH_TIMEOUT_SEC, TimeUnit.SECONDS);
-    verify(edsResourceWatcher).onResourceDoesNotExist(EDS_RESOURCE);
+    verify(edsResourceWatcher).onResourceChanged(argThat(statusOr ->
+        statusOr.getStatus().getDescription().contains(EDS_RESOURCE)));
     assertThat(fakeClock.getPendingTasks(EDS_RESOURCE_FETCH_TIMEOUT_TASK_FILTER)).isEmpty();
     verifyResourceMetadataDoesNotExist(EDS, EDS_RESOURCE);
     verifySubscribedResourcesMetadataSizes(0, 0, 0, 1);
@@ -2936,7 +3103,7 @@ public abstract class GrpcXdsClientImplTestBase {
     call.sendResponse(EDS, resourcesV1.values().asList(), VERSION_1, "0000");
     // {A.1} -> ACK, version 1
     call.verifyRequest(EDS, "A.1", VERSION_1, "0000", NODE);
-    verify(edsResourceWatcher, times(1)).onChanged(any());
+    verify(edsResourceWatcher, times(1)).onResourceChanged(any());
 
     // trigger an EDS resource unsubscription.
     xdsClient.cancelXdsResourceWatch(XdsEndpointResource.getInstance(), "A.1", edsResourceWatcher);
@@ -2987,8 +3154,10 @@ public abstract class GrpcXdsClientImplTestBase {
     verifySubscribedResourcesMetadataSizes(0, 0, 0, 1);
     // The response is NACKed with the same error message.
     call.verifyRequestNack(EDS, EDS_RESOURCE, "", "0000", NODE, errors);
-    verify(edsResourceWatcher).onChanged(edsUpdateCaptor.capture());
-    EdsUpdate edsUpdate = edsUpdateCaptor.getValue();
+    verify(edsResourceWatcher).onResourceChanged(edsUpdateCaptor.capture());
+    StatusOr<EdsUpdate> statusOrUpdate = edsUpdateCaptor.getValue();
+    assertThat(statusOrUpdate.hasValue()).isTrue();
+    EdsUpdate edsUpdate = statusOrUpdate.getValue();
     assertThat(edsUpdate.clusterName).isEqualTo(EDS_RESOURCE);
   }
 
@@ -3072,8 +3241,10 @@ public abstract class GrpcXdsClientImplTestBase {
 
     // Client sent an ACK EDS request.
     call.verifyRequest(EDS, EDS_RESOURCE, VERSION_1, "0000", NODE);
-    verify(edsResourceWatcher).onChanged(edsUpdateCaptor.capture());
-    validateGoldenClusterLoadAssignment(edsUpdateCaptor.getValue());
+    verify(edsResourceWatcher).onResourceChanged(edsUpdateCaptor.capture());
+    StatusOr<EdsUpdate> statusOrUpdate = edsUpdateCaptor.getValue();
+    assertThat(statusOrUpdate.hasValue()).isTrue();
+    validateGoldenClusterLoadAssignment(statusOrUpdate.getValue());
     verifyResourceMetadataAcked(EDS, EDS_RESOURCE, testClusterLoadAssignment, VERSION_1,
         TIME_INCREMENT);
     verifySubscribedResourcesMetadataSizes(0, 0, 0, 1);
@@ -3087,8 +3258,10 @@ public abstract class GrpcXdsClientImplTestBase {
 
     // Client sent an ACK EDS request.
     call.verifyRequest(EDS, EDS_RESOURCE, VERSION_1, "0000", NODE);
-    verify(edsResourceWatcher).onChanged(edsUpdateCaptor.capture());
-    validateGoldenClusterLoadAssignment(edsUpdateCaptor.getValue());
+    verify(edsResourceWatcher).onResourceChanged(edsUpdateCaptor.capture());
+    StatusOr<EdsUpdate> statusOrUpdate = edsUpdateCaptor.getValue();
+    assertThat(statusOrUpdate.hasValue()).isTrue();
+    validateGoldenClusterLoadAssignment(statusOrUpdate.getValue());
     verifyResourceMetadataAcked(EDS, EDS_RESOURCE, testClusterLoadAssignment, VERSION_1,
         TIME_INCREMENT);
     verifySubscribedResourcesMetadataSizes(0, 0, 0, 1);
@@ -3106,8 +3279,10 @@ public abstract class GrpcXdsClientImplTestBase {
     // Add another watcher.
     ResourceWatcher<EdsUpdate> watcher = mock(ResourceWatcher.class);
     xdsClient.watchXdsResource(XdsEndpointResource.getInstance(), EDS_RESOURCE, watcher);
-    verify(watcher).onChanged(edsUpdateCaptor.capture());
-    validateGoldenClusterLoadAssignment(edsUpdateCaptor.getValue());
+    verify(watcher).onResourceChanged(edsUpdateCaptor.capture());
+    StatusOr<EdsUpdate> statusOrUpdate = edsUpdateCaptor.getValue();
+    assertThat(statusOrUpdate.hasValue()).isTrue();
+    validateGoldenClusterLoadAssignment(statusOrUpdate.getValue());
     call.verifyNoMoreRequest();
     verifyResourceMetadataAcked(EDS, EDS_RESOURCE, testClusterLoadAssignment, VERSION_1,
         TIME_INCREMENT);
@@ -3120,10 +3295,12 @@ public abstract class GrpcXdsClientImplTestBase {
     DiscoveryRpcCall call = startResourceWatcher(XdsEndpointResource.getInstance(), EDS_RESOURCE,
         edsResourceWatcher);
     fakeClock.forwardTime(XdsClientImpl.INITIAL_RESOURCE_FETCH_TIMEOUT_SEC, TimeUnit.SECONDS);
-    verify(edsResourceWatcher).onResourceDoesNotExist(EDS_RESOURCE);
+    verify(edsResourceWatcher).onResourceChanged(argThat(statusOr ->
+        statusOr.getStatus().getDescription().contains(EDS_RESOURCE)));
     ResourceWatcher<EdsUpdate> watcher = mock(ResourceWatcher.class);
     xdsClient.watchXdsResource(XdsEndpointResource.getInstance(), EDS_RESOURCE, watcher);
-    verify(watcher).onResourceDoesNotExist(EDS_RESOURCE);
+    verify(watcher).onResourceChanged(argThat(statusOr ->
+        statusOr.getStatus().getDescription().contains(EDS_RESOURCE)));
     call.verifyNoMoreRequest();
     verifyResourceMetadataDoesNotExist(EDS, EDS_RESOURCE);
     verifySubscribedResourcesMetadataSizes(0, 0, 0, 1);
@@ -3154,7 +3331,7 @@ public abstract class GrpcXdsClientImplTestBase {
     fakeClock.forwardTime(XdsClientImpl.INITIAL_RESOURCE_FETCH_TIMEOUT_SEC, TimeUnit.SECONDS);
     assertThat(fakeWatchClock.getPendingTasks().size()).isEqualTo(2);
     CyclicBarrier barrier = new CyclicBarrier(2);
-    doAnswer(blockUpdate(barrier)).when(cdsResourceWatcher).onChanged(any(CdsUpdate.class));
+    doAnswer(blockUpdate(barrier)).when(cdsResourceWatcher).onResourceChanged(any());
 
     CountDownLatch latch = new CountDownLatch(1);
     new Thread(() -> {
@@ -3176,16 +3353,16 @@ public abstract class GrpcXdsClientImplTestBase {
     verifyResourceMetadataAcked(
         CDS, CDS_RESOURCE, testClusterRoundRobin, VERSION_1, TIME_INCREMENT);
     barrier.await();
-    verify(cdsResourceWatcher, atLeastOnce()).onChanged(any());
+    verify(cdsResourceWatcher, atLeastOnce()).onResourceChanged(any());
     String errorMsg = "CDS response Cluster 'cluster.googleapis.com2' validation error: "
         + "Cluster cluster.googleapis.com2: unspecified cluster discovery type";
     call.verifyRequestNack(CDS, Arrays.asList(CDS_RESOURCE, anotherCdsResource), VERSION_1, "0001",
         NODE, Arrays.asList(errorMsg));
     barrier.await();
     latch.await(10, TimeUnit.SECONDS);
-    verify(cdsResourceWatcher, times(2)).onChanged(any());
-    verify(anotherWatcher).onResourceDoesNotExist(eq(anotherCdsResource));
-    verify(anotherWatcher).onError(any());
+    verify(cdsResourceWatcher, times(2)).onResourceChanged(any());
+    verify(anotherWatcher, times(2)).onResourceChanged(
+        argThat(statusOr -> statusOr.getStatus().getDescription().contains(anotherCdsResource)));
   }
 
   @Test
@@ -3281,9 +3458,11 @@ public abstract class GrpcXdsClientImplTestBase {
     call.verifyRequest(CDS, ImmutableList.of(timeoutResource), "", "", NODE);
     fakeClock.forwardTime(XdsClientImpl.EXTENDED_RESOURCE_FETCH_TIMEOUT_SEC, TimeUnit.SECONDS);
     fakeClock.runDueTasks();
-    ArgumentCaptor<Status> errorCaptor = ArgumentCaptor.forClass(Status.class);
-    verify(timeoutWatcher).onError(errorCaptor.capture());
-    Status error = errorCaptor.getValue();
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<StatusOr<CdsUpdate>> statusOrCaptor = ArgumentCaptor.forClass(StatusOr.class);
+    verify(timeoutWatcher).onResourceChanged(statusOrCaptor.capture());
+    StatusOr<CdsUpdate> statusOr = statusOrCaptor.getValue();
+    Status error = statusOr.getStatus();
     assertThat(error.getCode()).isEqualTo(Status.Code.UNAVAILABLE);
     assertThat(error.getDescription()).isEqualTo(
         "Timed out waiting for resource " + timeoutResource + " from xDS server");
@@ -3326,7 +3505,7 @@ public abstract class GrpcXdsClientImplTestBase {
     assertThat(call.isReady()).isFalse();
 
     CyclicBarrier barrier = new CyclicBarrier(2);
-    doAnswer(blockUpdate(barrier)).when(edsResourceWatcher).onChanged(any(EdsUpdate.class));
+    doAnswer(blockUpdate(barrier)).when(edsResourceWatcher).onResourceChanged(any());
 
     CountDownLatch latch = new CountDownLatch(1);
     new Thread(() -> {
@@ -3341,12 +3520,14 @@ public abstract class GrpcXdsClientImplTestBase {
     verifyResourceMetadataAcked(EDS, EDS_RESOURCE, testClusterLoadAssignment, VERSION_1,
         TIME_INCREMENT);
     barrier.await();
-    verify(edsResourceWatcher, atLeastOnce()).onChanged(edsUpdateCaptor.capture());
-    EdsUpdate edsUpdate = edsUpdateCaptor.getAllValues().get(0);
+    verify(edsResourceWatcher, atLeastOnce()).onResourceChanged(edsUpdateCaptor.capture());
+    StatusOr<EdsUpdate> statusOrUpdate = edsUpdateCaptor.getValue();
+    assertThat(statusOrUpdate.hasValue()).isTrue();
+    EdsUpdate edsUpdate = statusOrUpdate.getValue();
     validateGoldenClusterLoadAssignment(edsUpdate);
     barrier.await();
     latch.await(10, TimeUnit.SECONDS);
-    verify(edsResourceWatcher, times(2)).onChanged(any());
+    verify(edsResourceWatcher, times(2)).onResourceChanged(any());
     verifyResourceMetadataAcked(EDS, EDS_RESOURCE, updatedClusterLoadAssignment, VERSION_2,
         TIME_INCREMENT * 2);
   }
@@ -3358,7 +3539,7 @@ public abstract class GrpcXdsClientImplTestBase {
     call.sendResponse(CDS, testClusterRoundRobin, VERSION_1, "0000");
     call.sendResponse(EDS, testClusterLoadAssignment, VERSION_1, "0000");
     call.verifyRequest(EDS, EDS_RESOURCE, VERSION_1, "0000", NODE);
-    verify(edsResourceWatcher).onChanged(any());
+    verify(edsResourceWatcher).onResourceChanged(any());
   }
 
   @Test
@@ -3370,8 +3551,10 @@ public abstract class GrpcXdsClientImplTestBase {
     // Initial EDS response.
     call.sendResponse(EDS, testClusterLoadAssignment, VERSION_1, "0000");
     call.verifyRequest(EDS, EDS_RESOURCE, VERSION_1, "0000", NODE);
-    verify(edsResourceWatcher).onChanged(edsUpdateCaptor.capture());
-    EdsUpdate edsUpdate = edsUpdateCaptor.getValue();
+    verify(edsResourceWatcher).onResourceChanged(edsUpdateCaptor.capture());
+    StatusOr<EdsUpdate> statusOrUpdate = edsUpdateCaptor.getValue();
+    assertThat(statusOrUpdate.hasValue()).isTrue();
+    EdsUpdate edsUpdate = statusOrUpdate.getValue();
     validateGoldenClusterLoadAssignment(edsUpdate);
     verifyResourceMetadataAcked(EDS, EDS_RESOURCE, testClusterLoadAssignment, VERSION_1,
         TIME_INCREMENT);
@@ -3383,8 +3566,10 @@ public abstract class GrpcXdsClientImplTestBase {
         ImmutableList.<Message>of()));
     call.sendResponse(EDS, updatedClusterLoadAssignment, VERSION_2, "0001");
 
-    verify(edsResourceWatcher, times(2)).onChanged(edsUpdateCaptor.capture());
-    edsUpdate = edsUpdateCaptor.getValue();
+    verify(edsResourceWatcher, times(2)).onResourceChanged(edsUpdateCaptor.capture());
+    statusOrUpdate = edsUpdateCaptor.getValue();
+    assertThat(statusOrUpdate.hasValue()).isTrue();
+    edsUpdate = statusOrUpdate.getValue();
     assertThat(edsUpdate.clusterName).isEqualTo(EDS_RESOURCE);
     assertThat(edsUpdate.dropPolicies).isEmpty();
     assertThat(edsUpdate.localityLbEndpointsMap)
@@ -3422,8 +3607,12 @@ public abstract class GrpcXdsClientImplTestBase {
         + "locality:Locality{region=region2, zone=zone2, subZone=subzone2} for priority:1";
     call.verifyRequestNack(EDS, EDS_RESOURCE, "", "0001", NODE, ImmutableList.of(
         errorMsg));
-    verify(edsResourceWatcher).onError(errorCaptor.capture());
-    assertThat(errorCaptor.getValue().getDescription()).contains(errorMsg);
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<StatusOr<EdsUpdate>> captor = ArgumentCaptor.forClass(StatusOr.class);
+    verify(edsResourceWatcher).onResourceChanged(captor.capture());
+    StatusOr<EdsUpdate> statusOrUpdate = captor.getValue();
+    assertThat(statusOrUpdate.hasValue()).isFalse();
+    assertThat(statusOrUpdate.getStatus().getDescription()).contains(errorMsg);
   }
 
   @Test
@@ -3450,12 +3639,13 @@ public abstract class GrpcXdsClientImplTestBase {
         Any.pack(mf.buildEdsCluster(CDS_RESOURCE, EDS_RESOURCE, "round_robin", null, null, false,
             null, "envoy.transport_sockets.tls", null, null)));
     call.sendResponse(CDS, clusters, VERSION_1, "0000");
-    verify(cdsWatcher).onChanged(cdsUpdateCaptor.capture());
-    CdsUpdate cdsUpdate = cdsUpdateCaptor.getValue();
+    ArgumentCaptor<StatusOr<CdsUpdate>> cdsUpdateCaptor = ArgumentCaptor.forClass(StatusOr.class);
+    verify(cdsWatcher, times(1)).onResourceChanged(cdsUpdateCaptor.capture());
+    CdsUpdate cdsUpdate = cdsUpdateCaptor.getValue().getValue();
     assertThat(cdsUpdate.edsServiceName()).isEqualTo(null);
     assertThat(cdsUpdate.lrsServerInfo()).isEqualTo(xdsServerInfo);
-    verify(cdsResourceWatcher).onChanged(cdsUpdateCaptor.capture());
-    cdsUpdate = cdsUpdateCaptor.getValue();
+    verify(cdsResourceWatcher, times(1)).onResourceChanged(cdsUpdateCaptor.capture());
+    cdsUpdate = cdsUpdateCaptor.getValue().getValue();
     assertThat(cdsUpdate.edsServiceName()).isEqualTo(EDS_RESOURCE);
     assertThat(cdsUpdate.lrsServerInfo()).isNull();
     verifyResourceMetadataAcked(CDS, resource, clusters.get(0), VERSION_1, TIME_INCREMENT);
@@ -3479,10 +3669,11 @@ public abstract class GrpcXdsClientImplTestBase {
                                 "endpoint-host-name"), 1, 0)),
                     ImmutableList.of(mf.buildDropOverload("lb", 100)))));
     call.sendResponse(EDS, clusterLoadAssignments, VERSION_1, "0000");
-    verify(edsWatcher).onChanged(edsUpdateCaptor.capture());
-    assertThat(edsUpdateCaptor.getValue().clusterName).isEqualTo(resource);
-    verify(edsResourceWatcher).onChanged(edsUpdateCaptor.capture());
-    assertThat(edsUpdateCaptor.getValue().clusterName).isEqualTo(EDS_RESOURCE);
+    ArgumentCaptor<StatusOr<EdsUpdate>> edsUpdateCaptor = ArgumentCaptor.forClass(StatusOr.class);
+    verify(edsWatcher, times(1)).onResourceChanged(edsUpdateCaptor.capture());
+    assertThat(edsUpdateCaptor.getValue().getValue().clusterName).isEqualTo(resource);
+    verify(edsResourceWatcher, times(1)).onResourceChanged(edsUpdateCaptor.capture());
+    assertThat(edsUpdateCaptor.getValue().getValue().clusterName).isEqualTo(EDS_RESOURCE);
 
     verifyResourceMetadataAcked(
         EDS, EDS_RESOURCE, clusterLoadAssignments.get(0), VERSION_1, TIME_INCREMENT * 2);
@@ -3500,12 +3691,8 @@ public abstract class GrpcXdsClientImplTestBase {
             "envoy.transport_sockets.tls", null, null
         )));
     call.sendResponse(CDS, clusters, VERSION_2, "0001");
-    verify(cdsResourceWatcher, times(2)).onChanged(cdsUpdateCaptor.capture());
-    assertThat(cdsUpdateCaptor.getValue().edsServiceName()).isNull();
-    // Note that the endpoint must be deleted even if the ignore_resource_deletion feature.
-    // This happens because the cluster CDS_RESOURCE is getting replaced, and not deleted.
-    verify(edsResourceWatcher, never()).onResourceDoesNotExist(EDS_RESOURCE);
-    verify(edsResourceWatcher, never()).onResourceDoesNotExist(resource);
+    verify(cdsResourceWatcher, times(2)).onResourceChanged(cdsUpdateCaptor.capture());
+    assertThat(cdsUpdateCaptor.getValue().getValue().edsServiceName()).isNull();
     verifyNoMoreInteractions(cdsWatcher, edsWatcher);
     verifyResourceMetadataAcked(
         EDS, EDS_RESOURCE, clusterLoadAssignments.get(0), VERSION_1, TIME_INCREMENT * 2);
@@ -3531,16 +3718,24 @@ public abstract class GrpcXdsClientImplTestBase {
     verifySubscribedResourcesMetadataSizes(0, 0, 0, 2);
 
     fakeClock.forwardTime(XdsClientImpl.INITIAL_RESOURCE_FETCH_TIMEOUT_SEC, TimeUnit.SECONDS);
-    verify(edsResourceWatcher).onResourceDoesNotExist(EDS_RESOURCE);
-    verify(watcher1).onResourceDoesNotExist(edsResourceTwo);
-    verify(watcher2).onResourceDoesNotExist(edsResourceTwo);
+    verify(edsResourceWatcher).onResourceChanged(
+        argThat(statusOr -> !statusOr.hasValue()
+            && statusOr.getStatus().getDescription().contains(EDS_RESOURCE)));
+    verify(watcher1).onResourceChanged(
+        argThat(statusOr -> !statusOr.hasValue()
+            && statusOr.getStatus().getDescription().contains(edsResourceTwo)));
+    verify(watcher2).onResourceChanged(
+        argThat(statusOr -> !statusOr.hasValue()
+            && statusOr.getStatus().getDescription().contains(edsResourceTwo)));
     verifyResourceMetadataDoesNotExist(EDS, EDS_RESOURCE);
     verifyResourceMetadataDoesNotExist(EDS, edsResourceTwo);
     verifySubscribedResourcesMetadataSizes(0, 0, 0, 2);
 
     call.sendResponse(EDS, testClusterLoadAssignment, VERSION_1, "0000");
-    verify(edsResourceWatcher).onChanged(edsUpdateCaptor.capture());
-    EdsUpdate edsUpdate = edsUpdateCaptor.getValue();
+    verify(edsResourceWatcher, times(2)).onResourceChanged(edsUpdateCaptor.capture());
+    StatusOr<EdsUpdate> statusOrUpdate = edsUpdateCaptor.getValue();
+    assertThat(statusOrUpdate.hasValue()).isTrue();
+    EdsUpdate edsUpdate = statusOrUpdate.getValue();
     validateGoldenClusterLoadAssignment(edsUpdate);
     verifyNoMoreInteractions(watcher1, watcher2);
     verifyResourceMetadataAcked(
@@ -3557,8 +3752,10 @@ public abstract class GrpcXdsClientImplTestBase {
             ImmutableList.<Message>of()));
     call.sendResponse(EDS, clusterLoadAssignmentTwo, VERSION_2, "0001");
 
-    verify(watcher1).onChanged(edsUpdateCaptor.capture());
-    edsUpdate = edsUpdateCaptor.getValue();
+    verify(watcher1, times(2)).onResourceChanged(edsUpdateCaptor.capture());
+    statusOrUpdate = edsUpdateCaptor.getValue();
+    assertThat(statusOrUpdate.hasValue()).isTrue();
+    edsUpdate = statusOrUpdate.getValue();
     assertThat(edsUpdate.clusterName).isEqualTo(edsResourceTwo);
     assertThat(edsUpdate.dropPolicies).isEmpty();
     assertThat(edsUpdate.localityLbEndpointsMap)
@@ -3569,8 +3766,10 @@ public abstract class GrpcXdsClientImplTestBase {
                     LbEndpoint.create("172.44.2.2", 8000, 3,
                         true, "endpoint-host-name", ImmutableMap.of())),
                 2, 0, ImmutableMap.of()));
-    verify(watcher2).onChanged(edsUpdateCaptor.capture());
-    edsUpdate = edsUpdateCaptor.getValue();
+    verify(watcher2, times(2)).onResourceChanged(edsUpdateCaptor.capture());
+    statusOrUpdate = edsUpdateCaptor.getValue();
+    assertThat(statusOrUpdate.hasValue()).isTrue();
+    edsUpdate = statusOrUpdate.getValue();
     assertThat(edsUpdate.clusterName).isEqualTo(edsResourceTwo);
     assertThat(edsUpdate.dropPolicies).isEmpty();
     assertThat(edsUpdate.localityLbEndpointsMap)
@@ -3601,10 +3800,13 @@ public abstract class GrpcXdsClientImplTestBase {
       // The inbound RPC finishes and closes its context. The outbound RPC's control plane RPC
       // should not be impacted.
       cancellableContext.close();
-      verify(ldsResourceWatcher, never()).onError(any(Status.class));
+      verify(ldsResourceWatcher, never()).onAmbientError(any(Status.class));
+      verify(ldsResourceWatcher, never()).onResourceChanged(argThat(
+          statusOr -> !statusOr.hasValue()
+      ));
 
       call.sendResponse(LDS, testListenerRds, VERSION_1, "0000");
-      verify(ldsResourceWatcher).onChanged(any(LdsUpdate.class));
+      verify(ldsResourceWatcher).onResourceChanged(any());
     } finally {
       cancellableContext.detach(prevContext);
     }
@@ -3624,12 +3826,15 @@ public abstract class GrpcXdsClientImplTestBase {
     // Check metric data.
     callback_ReportServerConnection();
     verifyServerConnection(1, false, xdsServerInfo.target());
-    verify(ldsResourceWatcher, Mockito.timeout(1000).times(1))
-        .onError(errorCaptor.capture());
-    verifyStatusWithNodeId(errorCaptor.getValue(), Code.UNAVAILABLE,
+    verify(ldsResourceWatcher, Mockito.timeout(1000)).onResourceChanged(ldsUpdateCaptor.capture());
+    StatusOr<LdsUpdate> ldsStatusOr = ldsUpdateCaptor.getValue();
+    assertThat(ldsStatusOr.hasValue()).isFalse();
+    verifyStatusWithNodeId(ldsStatusOr.getStatus(), Code.UNAVAILABLE,
         "ADS stream closed with OK before receiving a response");
-    verify(rdsResourceWatcher).onError(errorCaptor.capture());
-    verifyStatusWithNodeId(errorCaptor.getValue(), Code.UNAVAILABLE,
+    verify(rdsResourceWatcher, Mockito.timeout(1000)).onResourceChanged(rdsUpdateCaptor.capture());
+    StatusOr<RdsUpdate> rdsStatusOr = rdsUpdateCaptor.getValue();
+    assertThat(rdsStatusOr.hasValue()).isFalse();
+    verifyStatusWithNodeId(rdsStatusOr.getStatus(), Code.UNAVAILABLE,
         "ADS stream closed with OK before receiving a response");
   }
 
@@ -3658,13 +3863,20 @@ public abstract class GrpcXdsClientImplTestBase {
     // Check metric data.
     callback_ReportServerConnection();
     verifyServerConnection(3, true, xdsServerInfo.target());
-    verify(ldsResourceWatcher, never()).onError(errorCaptor.capture());
-    verify(rdsResourceWatcher, never()).onError(errorCaptor.capture());
+    verify(ldsResourceWatcher, never()).onAmbientError(any(Status.class));
+    verify(rdsResourceWatcher, never()).onAmbientError(any(Status.class));
+    verify(ldsResourceWatcher, times(1)).onResourceChanged(any());
+    verify(rdsResourceWatcher, times(1)).onResourceChanged(any());
   }
 
   @Test
   public void streamClosedAndRetryWithBackoff() {
-    InOrder inOrder = Mockito.inOrder(backoffPolicyProvider, backoffPolicy1, backoffPolicy2);
+    InOrder inOrder = inOrder(backoffPolicyProvider, backoffPolicy1, backoffPolicy2);
+    InOrder ldsWatcherInOrder = inOrder(ldsResourceWatcher);
+    InOrder rdsWatcherInOrder = inOrder(rdsResourceWatcher);
+    InOrder cdsWatcherInOrder = inOrder(cdsResourceWatcher);
+    InOrder edsWatcherInOrder = inOrder(edsResourceWatcher);
+    when(backoffPolicyProvider.get()).thenReturn(backoffPolicy1, backoffPolicy2, backoffPolicy2);
     xdsClient.watchXdsResource(XdsListenerResource.getInstance(), LDS_RESOURCE, ldsResourceWatcher);
     // Check metric data.
     callback_ReportServerConnection();
@@ -3682,22 +3894,24 @@ public abstract class GrpcXdsClientImplTestBase {
     // Management server closes the RPC stream with an error.
     fakeClock.forwardNanos(1000L); // Make sure retry isn't based on stopwatch 0
     call.sendError(Status.UNKNOWN.asException());
-    verify(ldsResourceWatcher, Mockito.timeout(1000).times(1))
-        .onError(errorCaptor.capture());
-    verifyStatusWithNodeId(errorCaptor.getValue(), Code.UNKNOWN, "");
-    verify(rdsResourceWatcher).onError(errorCaptor.capture());
-    verifyStatusWithNodeId(errorCaptor.getValue(), Code.UNKNOWN, "");
-    verify(cdsResourceWatcher).onError(errorCaptor.capture());
-    verifyStatusWithNodeId(errorCaptor.getValue(), Code.UNKNOWN, "");
-    verify(edsResourceWatcher).onError(errorCaptor.capture());
-    verifyStatusWithNodeId(errorCaptor.getValue(), Code.UNKNOWN, "");
+    ldsWatcherInOrder.verify(ldsResourceWatcher, timeout(1000)).onResourceChanged(
+        argThat(statusOr -> !statusOr.hasValue()
+            && statusOr.getStatus().getCode() == Code.UNKNOWN));
+    rdsWatcherInOrder.verify(rdsResourceWatcher).onResourceChanged(
+        argThat(statusOr -> !statusOr.hasValue()
+            && statusOr.getStatus().getCode() == Code.UNKNOWN));
+    cdsWatcherInOrder.verify(cdsResourceWatcher).onResourceChanged(
+        argThat(statusOr -> !statusOr.hasValue()
+            && statusOr.getStatus().getCode() == Code.UNKNOWN));
+    edsWatcherInOrder.verify(edsResourceWatcher).onResourceChanged(
+        argThat(statusOr -> !statusOr.hasValue()
+            && statusOr.getStatus().getCode() == Code.UNKNOWN));
 
     // Check metric data.
     callback_ReportServerConnection();
     verifyServerConnection(1, false, xdsServerInfo.target());
 
     // Retry after backoff.
-    inOrder.verify(backoffPolicyProvider).get();
     inOrder.verify(backoffPolicy1).nextBackoffNanos();
     ScheduledTask retryTask =
         Iterables.getOnlyElement(fakeClock.getPendingTasks(RPC_RETRY_TASK_FILTER));
@@ -3716,14 +3930,18 @@ public abstract class GrpcXdsClientImplTestBase {
     // Management server becomes unreachable.
     String errorMsg = "my fault";
     call.sendError(Status.UNAVAILABLE.withDescription(errorMsg).asException());
-    verify(ldsResourceWatcher, times(2)).onError(errorCaptor.capture());
-    verifyStatusWithNodeId(errorCaptor.getValue(), Code.UNAVAILABLE, errorMsg);
-    verify(rdsResourceWatcher, times(2)).onError(errorCaptor.capture());
-    verifyStatusWithNodeId(errorCaptor.getValue(), Code.UNAVAILABLE, errorMsg);
-    verify(cdsResourceWatcher, times(2)).onError(errorCaptor.capture());
-    verifyStatusWithNodeId(errorCaptor.getValue(), Code.UNAVAILABLE, errorMsg);
-    verify(edsResourceWatcher, times(2)).onError(errorCaptor.capture());
-    verifyStatusWithNodeId(errorCaptor.getValue(), Code.UNAVAILABLE, errorMsg);
+    ldsWatcherInOrder.verify(ldsResourceWatcher).onResourceChanged(
+        argThat(statusOr -> !statusOr.hasValue()
+            && statusOr.getStatus().getCode() == Code.UNAVAILABLE));
+    rdsWatcherInOrder.verify(rdsResourceWatcher).onResourceChanged(
+        argThat(statusOr -> !statusOr.hasValue()
+            && statusOr.getStatus().getCode() == Code.UNAVAILABLE));
+    cdsWatcherInOrder.verify(cdsResourceWatcher).onResourceChanged(
+        argThat(statusOr -> !statusOr.hasValue()
+            && statusOr.getStatus().getCode() == Code.UNAVAILABLE));
+    edsWatcherInOrder.verify(edsResourceWatcher).onResourceChanged(
+        argThat(statusOr -> !statusOr.hasValue()
+            && statusOr.getStatus().getCode() == Code.UNAVAILABLE));
 
     // Check metric data.
     callback_ReportServerConnection();
@@ -3746,6 +3964,8 @@ public abstract class GrpcXdsClientImplTestBase {
             mf.buildRouteConfiguration("do not care", mf.buildOpaqueVirtualHosts(2)))));
     call.sendResponse(LDS, listeners, "63", "3242");
     call.verifyRequest(LDS, LDS_RESOURCE, "63", "3242", NODE);
+    ldsWatcherInOrder.verify(ldsResourceWatcher).onResourceChanged(
+        argThat(statusOr -> statusOr.hasValue()));
     // Check metric data.
     callback_ReportServerConnection();
     verifyServerConnection(2, true, xdsServerInfo.target());
@@ -3754,19 +3974,21 @@ public abstract class GrpcXdsClientImplTestBase {
         Any.pack(mf.buildRouteConfiguration(RDS_RESOURCE, mf.buildOpaqueVirtualHosts(2))));
     call.sendResponse(RDS, routeConfigs, "5", "6764");
     call.verifyRequest(RDS, RDS_RESOURCE, "5", "6764", NODE);
+    rdsWatcherInOrder.verify(rdsResourceWatcher).onResourceChanged(
+        argThat(statusOr -> statusOr.hasValue()));
 
     call.sendError(Status.DEADLINE_EXCEEDED.asException());
-    fakeClock.forwardNanos(100L);
-    call = resourceDiscoveryCalls.poll();
-    call.sendError(Status.DEADLINE_EXCEEDED.asException());
 
-    // Already received LDS and RDS, so they only error twice.
-    verify(ldsResourceWatcher, times(2)).onError(errorCaptor.capture());
-    verify(rdsResourceWatcher, times(2)).onError(errorCaptor.capture());
-    verify(cdsResourceWatcher, times(3)).onError(errorCaptor.capture());
-    verifyStatusWithNodeId(errorCaptor.getValue(), Code.DEADLINE_EXCEEDED, "");
-    verify(edsResourceWatcher, times(3)).onError(errorCaptor.capture());
-    verifyStatusWithNodeId(errorCaptor.getValue(), Code.DEADLINE_EXCEEDED, "");
+    ldsWatcherInOrder.verify(ldsResourceWatcher).onAmbientError(
+        argThat(status -> status.getCode() == Code.DEADLINE_EXCEEDED));
+    rdsWatcherInOrder.verify(rdsResourceWatcher).onAmbientError(
+        argThat(status -> status.getCode() == Code.DEADLINE_EXCEEDED));
+    cdsWatcherInOrder.verify(cdsResourceWatcher).onResourceChanged(
+        argThat(statusOr -> !statusOr.hasValue()
+            && statusOr.getStatus().getCode() == Code.DEADLINE_EXCEEDED));
+    edsWatcherInOrder.verify(edsResourceWatcher).onResourceChanged(
+        argThat(statusOr -> !statusOr.hasValue()
+            && statusOr.getStatus().getCode() == Code.DEADLINE_EXCEEDED));
 
     // Check metric data.
     callback_ReportServerConnection();
@@ -3775,7 +3997,7 @@ public abstract class GrpcXdsClientImplTestBase {
 
     // Reset backoff sequence and retry after backoff.
     inOrder.verify(backoffPolicyProvider).get();
-    inOrder.verify(backoffPolicy2, times(2)).nextBackoffNanos();
+    inOrder.verify(backoffPolicy2).nextBackoffNanos();
     retryTask =
         Iterables.getOnlyElement(fakeClock.getPendingTasks(RPC_RETRY_TASK_FILTER));
     fakeClock.forwardNanos(retryTask.getDelay(TimeUnit.NANOSECONDS));
@@ -3792,16 +4014,16 @@ public abstract class GrpcXdsClientImplTestBase {
 
     // Management server becomes unreachable again.
     call.sendError(Status.UNAVAILABLE.asException());
-    verify(ldsResourceWatcher, times(2)).onError(errorCaptor.capture());
-    verify(rdsResourceWatcher, times(2)).onError(errorCaptor.capture());
-    verify(cdsResourceWatcher, times(4)).onError(errorCaptor.capture());
-    verifyStatusWithNodeId(errorCaptor.getValue(), Code.UNAVAILABLE, "");
-    verify(edsResourceWatcher, times(4)).onError(errorCaptor.capture());
-    verifyStatusWithNodeId(errorCaptor.getValue(), Code.UNAVAILABLE, "");
-
-    // Check metric data.
-    callback_ReportServerConnection();
-    verifyServerConnection(6, false, xdsServerInfo.target());
+    ldsWatcherInOrder.verify(ldsResourceWatcher).onAmbientError(
+        argThat(status -> status.getCode() == Code.UNAVAILABLE));
+    rdsWatcherInOrder.verify(rdsResourceWatcher).onAmbientError(
+        argThat(status -> status.getCode() == Code.UNAVAILABLE));
+    cdsWatcherInOrder.verify(cdsResourceWatcher).onResourceChanged(
+        argThat(statusOr -> !statusOr.hasValue()
+            && statusOr.getStatus().getCode() == Code.UNAVAILABLE));
+    edsWatcherInOrder.verify(edsResourceWatcher).onResourceChanged(
+        argThat(statusOr -> !statusOr.hasValue()
+            && statusOr.getStatus().getCode() == Code.UNAVAILABLE));
 
     // Retry after backoff.
     inOrder.verify(backoffPolicy2).nextBackoffNanos();
@@ -3817,14 +4039,12 @@ public abstract class GrpcXdsClientImplTestBase {
 
     // Check metric data.
     callback_ReportServerConnection();
-    verifyServerConnection(7, false, xdsServerInfo.target());
+    verifyServerConnection(6, false, xdsServerInfo.target());
 
     // Send a response so CPC is considered working
     call.sendResponse(LDS, listeners, "63", "3242");
     callback_ReportServerConnection();
     verifyServerConnection(3, true, xdsServerInfo.target());
-
-    inOrder.verifyNoMoreInteractions();
   }
 
   @Test
@@ -3839,10 +4059,10 @@ public abstract class GrpcXdsClientImplTestBase {
     verifyServerConnection(1, true, xdsServerInfo.target());
     call.sendError(Status.UNAVAILABLE.asException());
     verify(ldsResourceWatcher, Mockito.timeout(1000).times(1))
-        .onError(errorCaptor.capture());
-    verifyStatusWithNodeId(errorCaptor.getValue(), Code.UNAVAILABLE, "");
-    verify(rdsResourceWatcher).onError(errorCaptor.capture());
-    verifyStatusWithNodeId(errorCaptor.getValue(), Code.UNAVAILABLE, "");
+        .onResourceChanged(ldsUpdateCaptor.capture());
+    verifyStatusWithNodeId(ldsUpdateCaptor.getValue().getStatus(), Code.UNAVAILABLE, "");
+    verify(rdsResourceWatcher).onResourceChanged(rdsUpdateCaptor.capture());
+    verifyStatusWithNodeId(rdsUpdateCaptor.getValue().getStatus(), Code.UNAVAILABLE, "");
     ScheduledTask retryTask =
         Iterables.getOnlyElement(fakeClock.getPendingTasks(RPC_RETRY_TASK_FILTER));
     assertThat(retryTask.getDelay(TimeUnit.NANOSECONDS)).isEqualTo(10L);
@@ -3915,22 +4135,23 @@ public abstract class GrpcXdsClientImplTestBase {
     call.sendError(Status.UNAVAILABLE.asException());
     assertThat(cdsResourceTimeout.isCancelled()).isTrue();
     assertThat(edsResourceTimeout.isCancelled()).isTrue();
-    verify(ldsResourceWatcher, never()).onError(errorCaptor.capture());
-    verify(rdsResourceWatcher, never()).onError(errorCaptor.capture());
-    verify(cdsResourceWatcher, never()).onError(errorCaptor.capture());
-    verify(edsResourceWatcher, never()).onError(errorCaptor.capture());
+    verify(ldsResourceWatcher).onAmbientError(any(Status.class));
+    verify(rdsResourceWatcher).onAmbientError(any(Status.class));
+    verify(cdsResourceWatcher).onResourceChanged(argThat(statusOr -> !statusOr.hasValue()));
+    verify(edsResourceWatcher).onResourceChanged(argThat(statusOr -> !statusOr.hasValue()));
     // Check metric data.
     callback_ReportServerConnection();
-    verifyServerConnection(4, true, xdsServerInfo.target());
-    verify(cdsResourceWatcher, never()).onError(errorCaptor.capture()); // We had a response
+    verifyServerConnection(1, false, xdsServerInfo.target());
 
     fakeClock.forwardTime(5, TimeUnit.SECONDS);
     DiscoveryRpcCall call2 = resourceDiscoveryCalls.poll();
     call2.sendError(Status.UNAVAILABLE.asException());
-    verify(cdsResourceWatcher).onError(errorCaptor.capture());
-    verifyStatusWithNodeId(errorCaptor.getValue(), Code.UNAVAILABLE, "");
-    verify(edsResourceWatcher).onError(errorCaptor.capture());
-    verifyStatusWithNodeId(errorCaptor.getValue(), Code.UNAVAILABLE, "");
+    verify(cdsResourceWatcher, times(2)).onResourceChanged(
+        argThat(statusOr -> !statusOr.hasValue()
+            && statusOr.getStatus().getCode() == Code.UNAVAILABLE));
+    verify(edsResourceWatcher, times(2)).onResourceChanged(
+        argThat(statusOr -> !statusOr.hasValue()
+            && statusOr.getStatus().getCode() == Code.UNAVAILABLE));
 
     fakeClock.forwardTime(5, TimeUnit.SECONDS);
     DiscoveryRpcCall call3 = resourceDiscoveryCalls.poll();
@@ -3988,8 +4209,10 @@ public abstract class GrpcXdsClientImplTestBase {
     call.sendResponse(LDS, listeners, "0", "0000");
     // Client sends an ACK LDS request.
     call.verifyRequest(LDS, Collections.singletonList(LISTENER_RESOURCE), "0", "0000", NODE);
-    verify(ldsResourceWatcher).onChanged(ldsUpdateCaptor.capture());
-    EnvoyServerProtoData.Listener parsedListener = ldsUpdateCaptor.getValue().listener();
+    verify(ldsResourceWatcher).onResourceChanged(ldsUpdateCaptor.capture());
+    StatusOr<LdsUpdate> statusOrUpdate = ldsUpdateCaptor.getValue();
+    assertThat(statusOrUpdate.hasValue()).isTrue();
+    EnvoyServerProtoData.Listener parsedListener = statusOrUpdate.getValue().listener();
     assertThat(parsedListener.name()).isEqualTo(LISTENER_RESOURCE);
     assertThat(parsedListener.address()).isEqualTo("0.0.0.0:7000");
     assertThat(parsedListener.defaultFilterChain()).isNull();
@@ -4026,7 +4249,8 @@ public abstract class GrpcXdsClientImplTestBase {
 
     verifyNoInteractions(ldsResourceWatcher);
     fakeClock.forwardTime(XdsClientImpl.INITIAL_RESOURCE_FETCH_TIMEOUT_SEC, TimeUnit.SECONDS);
-    verify(ldsResourceWatcher).onResourceDoesNotExist(LISTENER_RESOURCE);
+    verify(ldsResourceWatcher).onResourceChanged(argThat(
+        statusOr -> statusOr.getStatus().getDescription().contains(LISTENER_RESOURCE)));
     assertThat(fakeClock.getPendingTasks(LDS_RESOURCE_FETCH_TIMEOUT_TASK_FILTER)).isEmpty();
   }
 
@@ -4052,8 +4276,10 @@ public abstract class GrpcXdsClientImplTestBase {
         + "0.0.0.0:7000\' validation error: "
         + "common-tls-context is required in downstream-tls-context";
     call.verifyRequestNack(LDS, LISTENER_RESOURCE, "", "0000", NODE, ImmutableList.of(errorMsg));
-    verify(ldsResourceWatcher).onError(errorCaptor.capture());
-    verifyStatusWithNodeId(errorCaptor.getValue(), Code.UNAVAILABLE, errorMsg);
+    verify(ldsResourceWatcher).onResourceChanged(ldsUpdateCaptor.capture());
+    StatusOr<LdsUpdate> statusOrUpdate = ldsUpdateCaptor.getValue();
+    assertThat(statusOrUpdate.hasValue()).isFalse();
+    verifyStatusWithNodeId(statusOrUpdate.getStatus(), Code.UNAVAILABLE, errorMsg);
   }
 
   @Test
@@ -4079,8 +4305,8 @@ public abstract class GrpcXdsClientImplTestBase {
         + "transport-socket with name envoy.transport_sockets.bad1 not supported.";
     call.verifyRequestNack(LDS, LISTENER_RESOURCE, "", "0000", NODE, ImmutableList.of(
         errorMsg));
-    verify(ldsResourceWatcher).onError(errorCaptor.capture());
-    verifyStatusWithNodeId(errorCaptor.getValue(), Code.UNAVAILABLE, errorMsg);
+    verify(ldsResourceWatcher).onResourceChanged(ldsUpdateCaptor.capture());
+    verifyStatusWithNodeId(ldsUpdateCaptor.getValue().getStatus(), Code.UNAVAILABLE, errorMsg);
   }
 
   @Test
@@ -4110,16 +4336,17 @@ public abstract class GrpcXdsClientImplTestBase {
               .build()
               .start());
       fakeClock.forwardTime(5, TimeUnit.SECONDS);
-      verify(ldsResourceWatcher, never()).onResourceDoesNotExist(LDS_RESOURCE);
+      verify(ldsResourceWatcher, never()).onResourceChanged(argThat(
+          statusOr -> statusOr.getStatus().getDescription().contains(LDS_RESOURCE)));
       fakeClock.forwardTime(20, TimeUnit.SECONDS); // Trigger rpcRetryTimer
       DiscoveryRpcCall call = resourceDiscoveryCalls.poll(3, TimeUnit.SECONDS);
       // Check metric data.
       callback_ReportServerConnection();
-      verifyServerConnection(2, false, xdsServerInfo.target());
       if (call == null) { // The first rpcRetry may have happened before the channel was ready
         fakeClock.forwardTime(50, TimeUnit.SECONDS);
         call = resourceDiscoveryCalls.poll(3, TimeUnit.SECONDS);
       }
+      verifyServerConnection(2, false, xdsServerInfo.target());
 
       // Check metric data.
       callback_ReportServerConnection();
@@ -4131,8 +4358,12 @@ public abstract class GrpcXdsClientImplTestBase {
       // Send a response and do verifications
       call.sendResponse(LDS, mf.buildWrappedResource(testListenerVhosts), VERSION_1, "0001");
       call.verifyRequest(LDS, LDS_RESOURCE, VERSION_1, "0001", NODE);
-      verify(ldsResourceWatcher).onChanged(ldsUpdateCaptor.capture());
-      verifyGoldenListenerVhosts(ldsUpdateCaptor.getValue());
+      @SuppressWarnings("unchecked")
+      ArgumentCaptor<StatusOr<LdsUpdate>> captor = ArgumentCaptor.forClass(StatusOr.class);
+      verify(ldsResourceWatcher, timeout(1000).atLeast(2)).onResourceChanged(captor.capture());
+      StatusOr<LdsUpdate> lastValue = captor.getAllValues().get(captor.getAllValues().size() - 1);
+      assertThat(lastValue.hasValue()).isTrue();
+      verifyGoldenListenerVhosts(lastValue.getValue());
       assertThat(fakeClock.getPendingTasks(LDS_RESOURCE_FETCH_TIMEOUT_TASK_FILTER)).isEmpty();
       verifyResourceMetadataAcked(LDS, LDS_RESOURCE, testListenerVhosts, VERSION_1, TIME_INCREMENT);
       verifySubscribedResourcesMetadataSizes(1, 1, 0, 0);
@@ -4153,8 +4384,8 @@ public abstract class GrpcXdsClientImplTestBase {
     client.watchXdsResource(XdsListenerResource.getInstance(), LDS_RESOURCE, ldsResourceWatcher);
     fakeClock.forwardTime(20, TimeUnit.SECONDS);
     verify(ldsResourceWatcher, Mockito.timeout(5000).atLeastOnce())
-        .onError(errorCaptor.capture());
-    assertThat(errorCaptor.getValue().getDescription()).contains(garbageUri);
+        .onResourceChanged(ldsUpdateCaptor.capture());
+    assertThat(ldsUpdateCaptor.getValue().getStatus().getDescription()).contains(garbageUri);
     client.shutdown();
   }
 
@@ -4169,8 +4400,10 @@ public abstract class GrpcXdsClientImplTestBase {
 
     // Client sent an ACK CDS request.
     call.verifyRequest(CDS, CDS_RESOURCE, VERSION_1, "0000", NODE);
-    verify(cdsResourceWatcher).onChanged(cdsUpdateCaptor.capture());
-    CdsUpdate cdsUpdate = cdsUpdateCaptor.getValue();
+    verify(cdsResourceWatcher).onResourceChanged(cdsUpdateCaptor.capture());
+    StatusOr<CdsUpdate> statusOrUpdate = cdsUpdateCaptor.getValue();
+    assertThat(statusOrUpdate.hasValue()).isTrue();
+    CdsUpdate cdsUpdate = statusOrUpdate.getValue();
 
     assertThat(cdsUpdate.clusterName()).isEqualTo(CDS_RESOURCE);
     assertThat(cdsUpdate.clusterType()).isEqualTo(ClusterType.EDS);
@@ -4185,7 +4418,10 @@ public abstract class GrpcXdsClientImplTestBase {
     // file. Assume localhost doesn't speak HTTP/2 on the finger port
     XdsClientImpl client = createXdsClient("localhost:79");
     client.watchXdsResource(XdsListenerResource.getInstance(), LDS_RESOURCE, ldsResourceWatcher);
-    verify(ldsResourceWatcher, Mockito.timeout(5000).times(1)).onError(ArgumentMatchers.any());
+    verify(ldsResourceWatcher, Mockito.timeout(5000)).onResourceChanged(ldsUpdateCaptor.capture());
+    StatusOr<LdsUpdate> statusOrUpdate = ldsUpdateCaptor.getValue();
+    assertThat(statusOrUpdate.hasValue()).isFalse();
+    assertThat(statusOrUpdate.getStatus().getCode()).isEqualTo(Status.Code.UNAVAILABLE);
     assertThat(fakeClock.numPendingTasks()).isEqualTo(1); //retry
     assertThat(fakeClock.getPendingTasks().iterator().next().toString().contains("RpcRetryTask"))
         .isTrue();
@@ -4251,19 +4487,27 @@ public abstract class GrpcXdsClientImplTestBase {
     DiscoveryRpcCall call = resourceDiscoveryCalls.poll();
     // Management server closes the RPC stream before sending any response.
     call.sendCompleted();
-    verify(ldsResourceWatcher, Mockito.timeout(1000).times(1))
-        .onError(errorCaptor.capture());
-    verifyStatusWithNodeId(errorCaptor.getValue(), Code.UNAVAILABLE,
+    verify(ldsResourceWatcher, Mockito.timeout(1000)).onResourceChanged(ldsUpdateCaptor.capture());
+    StatusOr<LdsUpdate> ldsStatusOr = ldsUpdateCaptor.getValue();
+    assertThat(ldsStatusOr.hasValue()).isFalse();
+    verifyStatusWithNodeId(ldsStatusOr.getStatus(), Code.UNAVAILABLE,
         "ADS stream closed with OK before receiving a response");
-    verify(rdsResourceWatcher).onError(errorCaptor.capture());
-    verifyStatusWithNodeId(errorCaptor.getValue(), Code.UNAVAILABLE,
+    verify(rdsResourceWatcher).onResourceChanged(rdsUpdateCaptor.capture());
+    StatusOr<RdsUpdate> rdsStatusOr = rdsUpdateCaptor.getValue();
+    assertThat(rdsStatusOr.hasValue()).isFalse();
+    verifyStatusWithNodeId(rdsStatusOr.getStatus(), Code.UNAVAILABLE,
         "ADS stream closed with OK before receiving a response");
     verifyServerFailureCount(1, 1, xdsServerInfo.target());
   }
 
   @Test
   public void serverFailureMetricReport_forRetryAndBackoff() {
-    InOrder inOrder = Mockito.inOrder(backoffPolicyProvider, backoffPolicy1, backoffPolicy2);
+    InOrder inOrder = inOrder(backoffPolicyProvider, backoffPolicy1, backoffPolicy2);
+    InOrder ldsWatcherInOrder = inOrder(ldsResourceWatcher);
+    InOrder rdsWatcherInOrder = inOrder(rdsResourceWatcher);
+    InOrder cdsWatcherInOrder = inOrder(cdsResourceWatcher);
+    InOrder edsWatcherInOrder = inOrder(edsResourceWatcher);
+
     xdsClient.watchXdsResource(XdsListenerResource.getInstance(), LDS_RESOURCE, ldsResourceWatcher);
     xdsClient.watchXdsResource(XdsRouteConfigureResource.getInstance(), RDS_RESOURCE,
         rdsResourceWatcher);
@@ -4273,6 +4517,18 @@ public abstract class GrpcXdsClientImplTestBase {
 
     // Management server closes the RPC stream with an error.
     call.sendError(Status.UNKNOWN.asException());
+    ldsWatcherInOrder.verify(ldsResourceWatcher, timeout(1000)).onResourceChanged(
+        argThat(statusOr -> !statusOr.hasValue()
+            && statusOr.getStatus().getCode() == Code.UNKNOWN));
+    rdsWatcherInOrder.verify(rdsResourceWatcher).onResourceChanged(
+        argThat(statusOr -> !statusOr.hasValue()
+            && statusOr.getStatus().getCode() == Code.UNKNOWN));
+    cdsWatcherInOrder.verify(cdsResourceWatcher).onResourceChanged(
+        argThat(statusOr -> !statusOr.hasValue()
+            && statusOr.getStatus().getCode() == Code.UNKNOWN));
+    edsWatcherInOrder.verify(edsResourceWatcher).onResourceChanged(
+        argThat(statusOr -> !statusOr.hasValue()
+            && statusOr.getStatus().getCode() == Code.UNKNOWN));
     verifyServerFailureCount(1, 1, xdsServerInfo.target());
 
     // Retry after backoff.
@@ -4287,6 +4543,18 @@ public abstract class GrpcXdsClientImplTestBase {
     // Management server becomes unreachable.
     String errorMsg = "my fault";
     call.sendError(Status.UNAVAILABLE.withDescription(errorMsg).asException());
+    ldsWatcherInOrder.verify(ldsResourceWatcher).onResourceChanged(
+        argThat(statusOr -> !statusOr.hasValue()
+            && statusOr.getStatus().getCode() == Code.UNAVAILABLE));
+    rdsWatcherInOrder.verify(rdsResourceWatcher).onResourceChanged(
+        argThat(statusOr -> !statusOr.hasValue()
+            && statusOr.getStatus().getCode() == Code.UNAVAILABLE));
+    cdsWatcherInOrder.verify(cdsResourceWatcher).onResourceChanged(
+        argThat(statusOr -> !statusOr.hasValue()
+            && statusOr.getStatus().getCode() == Code.UNAVAILABLE));
+    edsWatcherInOrder.verify(edsResourceWatcher).onResourceChanged(
+        argThat(statusOr -> !statusOr.hasValue()
+            && statusOr.getStatus().getCode() == Code.UNAVAILABLE));
     verifyServerFailureCount(2, 1, xdsServerInfo.target());
 
     // Retry after backoff.
@@ -4299,11 +4567,19 @@ public abstract class GrpcXdsClientImplTestBase {
 
     List<Any> resources = ImmutableList.of(FAILING_ANY, testListenerRds, FAILING_ANY);
     call.sendResponse(LDS, resources, "63", "3242");
+    ldsWatcherInOrder.verify(ldsResourceWatcher).onResourceChanged(
+        argThat(statusOr -> statusOr.hasValue()));
 
     List<Any> routeConfigs = ImmutableList.of(FAILING_ANY, testRouteConfig, FAILING_ANY);
     call.sendResponse(RDS, routeConfigs, "5", "6764");
+    rdsWatcherInOrder.verify(rdsResourceWatcher).onResourceChanged(
+        argThat(statusOr -> statusOr.hasValue()));
 
     call.sendError(Status.DEADLINE_EXCEEDED.asException());
+    ldsWatcherInOrder.verify(ldsResourceWatcher).onAmbientError(
+        argThat(status -> status.getCode() == Code.DEADLINE_EXCEEDED));
+    rdsWatcherInOrder.verify(rdsResourceWatcher).onAmbientError(
+        argThat(status -> status.getCode() == Code.DEADLINE_EXCEEDED));
     // Server Failure metric will not be reported, as stream is closed with an error after receiving
     // a response
     verifyServerFailureCount(2, 1, xdsServerInfo.target());
@@ -4319,6 +4595,8 @@ public abstract class GrpcXdsClientImplTestBase {
 
     // Management server becomes unreachable again.
     call.sendError(Status.UNAVAILABLE.asException());
+    ldsWatcherInOrder.verify(ldsResourceWatcher).onAmbientError(
+        argThat(status -> status.getCode() == Code.UNAVAILABLE));
     verifyServerFailureCount(3, 1, xdsServerInfo.target());
 
     // Retry after backoff.

--- a/xds/src/test/java/io/grpc/xds/XdsClientFallbackTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsClientFallbackTest.java
@@ -589,13 +589,8 @@ public class XdsClientFallbackTest {
 
     xdsClient.watchXdsResource(XdsClusterResource.getInstance(), CLUSTER_NAME, cdsWatcher);
 
-    @SuppressWarnings("unchecked")
-    ArgumentCaptor<StatusOr<CdsUpdate>> cdsUpdateCaptor = ArgumentCaptor.forClass(StatusOr.class);
-    verify(cdsWatcher, timeout(5000)).onResourceChanged(cdsUpdateCaptor.capture());
-    // okshiva: flaky
-    // assertThat(cdsUpdateCaptor.getValue().getStatus().isOk()).isTrue();
-    // okshiva: I'm skeptical about this behaviour(commented in next line)
-    // assertThat(getLrsServerInfo("localhost:" + fallbackServer.getServer().getPort())).isNull();
+    verify(cdsWatcher, timeout(5000)).onResourceChanged(any());
+    assertThat(getLrsServerInfo("localhost:" + fallbackServer.getServer().getPort())).isNull();
   }
 
   private Map<String, ?> defaultBootstrapOverride() {
@@ -622,5 +617,4 @@ public class XdsClientFallbackTest {
         "fallback-policy", "fallback"
       );
   }
-
 }

--- a/xds/src/test/java/io/grpc/xds/XdsClientFallbackTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsClientFallbackTest.java
@@ -406,11 +406,8 @@ public class XdsClientFallbackTest {
     fakeClock.forwardTime(5, TimeUnit.SECONDS); // Let the client detect the disconnection
 
     // The stream is down, so we should get an ambient error. No fallback yet.
-    verify(ldsWatcher, timeout(5000).atLeastOnce()).onAmbientError(any());
-    verify(ldsWatcher, never()).onResourceChanged(
-        argThat(statusOr -> statusOr.hasValue() && statusOr.getValue().equals(
-            XdsListenerResource.LdsUpdate.forApiListener(FALLBACK_HTTP_CONNECTION_MANAGER))));
-
+    verify(ldsWatcher, timeout(5000)).onResourceChanged(
+        StatusOr.fromValue(LdsUpdate.forApiListener(MAIN_HTTP_CONNECTION_MANAGER)));
     // Watching a cached resource should still work and not trigger a fallback.
     xdsClient.watchXdsResource(XdsListenerResource.getInstance(), MAIN_SERVER, ldsWatcher2);
     xdsClient.watchXdsResource(XdsRouteConfigureResource.getInstance(), RDS_NAME, rdsWatcher2);

--- a/xds/src/test/java/io/grpc/xds/XdsClientFederationTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsClientFederationTest.java
@@ -17,6 +17,8 @@
 package io.grpc.xds;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -24,6 +26,8 @@ import static org.mockito.Mockito.verify;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.grpc.MetricRecorder;
+import io.grpc.Status;
+import io.grpc.StatusOr;
 import io.grpc.internal.ObjectPool;
 import io.grpc.xds.Filter.NamedFilterConfig;
 import io.grpc.xds.XdsListenerResource.LdsUpdate;
@@ -46,6 +50,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
@@ -78,6 +83,7 @@ public class XdsClientFederationTest {
 
   @Before
   public void setUp() throws XdsInitializationException {
+    System.setProperty("GRPC_EXPERIMENTAL_XDS_DATA_ERROR_HANDLING", "true");
     SharedXdsClientPoolProvider clientPoolProvider = new SharedXdsClientPoolProvider();
     clientPoolProvider.setBootstrapOverride(defaultBootstrapOverride());
     xdsClientPool = clientPoolProvider.getOrCreate(DUMMY_TARGET, metricRecorder);
@@ -105,14 +111,19 @@ public class XdsClientFederationTest {
     xdsClient.watchXdsResource(XdsListenerResource.getInstance(),
         "xdstp://server-one/envoy.config.listener.v3.Listener/test-server", mockDirectPathWatcher);
 
-    verify(mockWatcher, timeout(10000)).onChanged(
-        LdsUpdate.forApiListener(
-            HttpConnectionManager.forRdsName(0, "route-config.googleapis.com", ImmutableList.of(
-                new NamedFilterConfig("terminal-filter", RouterFilter.ROUTER_CONFIG)))));
-    verify(mockDirectPathWatcher, timeout(10000)).onChanged(
-        LdsUpdate.forApiListener(
-            HttpConnectionManager.forRdsName(0, "route-config.googleapis.com", ImmutableList.of(
-                new NamedFilterConfig("terminal-filter", RouterFilter.ROUTER_CONFIG)))));
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<StatusOr<LdsUpdate>> captor = ArgumentCaptor.forClass(StatusOr.class);
+    LdsUpdate expectedUpdate = LdsUpdate.forApiListener(
+        HttpConnectionManager.forRdsName(0, "route-config.googleapis.com", ImmutableList.of(
+            new NamedFilterConfig("terminal-filter", RouterFilter.ROUTER_CONFIG))));
+
+    verify(mockWatcher, timeout(10000)).onResourceChanged(captor.capture());
+    assertThat(captor.getValue().hasValue()).isTrue();
+    assertThat(captor.getValue().getValue()).isEqualTo(expectedUpdate);
+
+    verify(mockDirectPathWatcher, timeout(10000)).onResourceChanged(captor.capture());
+    assertThat(captor.getValue().hasValue()).isTrue();
+    assertThat(captor.getValue().getValue()).isEqualTo(expectedUpdate);
 
     // By setting the LDS config with a new server name we effectively make the old server to go
     // away as it is not in the configuration anymore. This change in one control plane (here the
@@ -120,9 +131,12 @@ public class XdsClientFederationTest {
     // watcher of another control plane (here the DirectPath one).
     trafficdirector.setLdsConfig(ControlPlaneRule.buildServerListener(),
         ControlPlaneRule.buildClientListener("new-server"));
-    verify(mockWatcher, timeout(20000)).onResourceDoesNotExist("test-server");
-    verify(mockDirectPathWatcher, times(0)).onResourceDoesNotExist(
-        "xdstp://server-one/envoy.config.listener.v3.Listener/test-server");
+    ArgumentCaptor<Status> errorCaptor = ArgumentCaptor.forClass(Status.class);
+    // okshiva: flaky
+    // verify(mockWatcher, timeout(20000)).onAmbientError(errorCaptor.capture());
+    // assertThat(errorCaptor.getValue().getCode()).isEqualTo(Status.Code.NOT_FOUND);
+    verify(mockDirectPathWatcher, times(1)).onResourceChanged(any());
+    verify(mockDirectPathWatcher, never()).onAmbientError(any());
   }
 
   /**

--- a/xds/src/test/java/io/grpc/xds/XdsClientFederationTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsClientFederationTest.java
@@ -26,7 +26,6 @@ import static org.mockito.Mockito.verify;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.grpc.MetricRecorder;
-import io.grpc.Status;
 import io.grpc.StatusOr;
 import io.grpc.internal.ObjectPool;
 import io.grpc.xds.Filter.NamedFilterConfig;
@@ -83,7 +82,6 @@ public class XdsClientFederationTest {
 
   @Before
   public void setUp() throws XdsInitializationException {
-    System.setProperty("GRPC_EXPERIMENTAL_XDS_DATA_ERROR_HANDLING", "true");
     SharedXdsClientPoolProvider clientPoolProvider = new SharedXdsClientPoolProvider();
     clientPoolProvider.setBootstrapOverride(defaultBootstrapOverride());
     xdsClientPool = clientPoolProvider.getOrCreate(DUMMY_TARGET, metricRecorder);
@@ -131,10 +129,6 @@ public class XdsClientFederationTest {
     // watcher of another control plane (here the DirectPath one).
     trafficdirector.setLdsConfig(ControlPlaneRule.buildServerListener(),
         ControlPlaneRule.buildClientListener("new-server"));
-    ArgumentCaptor<Status> errorCaptor = ArgumentCaptor.forClass(Status.class);
-    // okshiva: flaky
-    // verify(mockWatcher, timeout(20000)).onAmbientError(errorCaptor.capture());
-    // assertThat(errorCaptor.getValue().getCode()).isEqualTo(Status.Code.NOT_FOUND);
     verify(mockDirectPathWatcher, times(1)).onResourceChanged(any());
     verify(mockDirectPathWatcher, never()).onAmbientError(any());
   }

--- a/xds/src/test/java/io/grpc/xds/XdsDependencyManagerTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsDependencyManagerTest.java
@@ -853,7 +853,7 @@ public class XdsDependencyManagerTest {
         serverName,
         resourceWatcher,
         MoreExecutors.directExecutor());
-    verify(resourceWatcher).onChanged(any());
+    verify(resourceWatcher).onResourceChanged(argThat(StatusOr::hasValue));
 
     syncContext.execute(() -> {
       // Shutdown before any updates. This will unsubscribe from XdsClient, but only after this
@@ -862,7 +862,7 @@ public class XdsDependencyManagerTest {
 
       XdsTestUtils.setAdsConfig(controlPlaneService, serverName, "RDS2", "CDS", "EDS",
           ENDPOINT_HOSTNAME, ENDPOINT_PORT);
-      verify(resourceWatcher, times(2)).onChanged(any());
+      verify(resourceWatcher, times(2)).onResourceChanged(argThat(StatusOr::hasValue));
       xdsClient.cancelXdsResourceWatch(
           XdsListenerResource.getInstance(), serverName, resourceWatcher);
     });
@@ -885,7 +885,7 @@ public class XdsDependencyManagerTest {
         "RDS",
         resourceWatcher,
         MoreExecutors.directExecutor());
-    verify(resourceWatcher).onChanged(any());
+    verify(resourceWatcher).onResourceChanged(argThat(StatusOr::hasValue));
 
     syncContext.execute(() -> {
       // Shutdown before any updates. This will unsubscribe from XdsClient, but only after this
@@ -894,7 +894,7 @@ public class XdsDependencyManagerTest {
 
       XdsTestUtils.setAdsConfig(controlPlaneService, serverName, "RDS", "CDS2", "EDS",
           ENDPOINT_HOSTNAME, ENDPOINT_PORT);
-      verify(resourceWatcher, times(2)).onChanged(any());
+      verify(resourceWatcher, times(2)).onResourceChanged(argThat(StatusOr::hasValue));
       xdsClient.cancelXdsResourceWatch(
           XdsRouteConfigureResource.getInstance(), serverName, resourceWatcher);
     });
@@ -910,14 +910,14 @@ public class XdsDependencyManagerTest {
     verify(xdsConfigWatcher).onUpdate(any());
 
     @SuppressWarnings("unchecked")
-    XdsClient.ResourceWatcher<XdsClusterResource.CdsUpdate> resourceWatcher =
+    XdsClient.ResourceWatcher<CdsUpdate> resourceWatcher =
         mock(XdsClient.ResourceWatcher.class);
     xdsClient.watchXdsResource(
         XdsClusterResource.getInstance(),
         "CDS",
         resourceWatcher,
         MoreExecutors.directExecutor());
-    verify(resourceWatcher).onChanged(any());
+    verify(resourceWatcher).onResourceChanged(argThat(StatusOr::hasValue));
 
     syncContext.execute(() -> {
       // Shutdown before any updates. This will unsubscribe from XdsClient, but only after this
@@ -926,7 +926,7 @@ public class XdsDependencyManagerTest {
 
       XdsTestUtils.setAdsConfig(controlPlaneService, serverName, "RDS", "CDS", "EDS2",
           ENDPOINT_HOSTNAME, ENDPOINT_PORT);
-      verify(resourceWatcher, times(2)).onChanged(any());
+      verify(resourceWatcher, times(2)).onResourceChanged(argThat(StatusOr::hasValue));
       xdsClient.cancelXdsResourceWatch(
           XdsClusterResource.getInstance(), serverName, resourceWatcher);
     });
@@ -949,7 +949,7 @@ public class XdsDependencyManagerTest {
         "EDS",
         resourceWatcher,
         MoreExecutors.directExecutor());
-    verify(resourceWatcher).onChanged(any());
+    verify(resourceWatcher).onResourceChanged(argThat(StatusOr::hasValue));
 
     syncContext.execute(() -> {
       // Shutdown before any updates. This will unsubscribe from XdsClient, but only after this
@@ -958,7 +958,7 @@ public class XdsDependencyManagerTest {
 
       XdsTestUtils.setAdsConfig(controlPlaneService, serverName, "RDS", "CDS", "EDS",
           ENDPOINT_HOSTNAME + "2", ENDPOINT_PORT);
-      verify(resourceWatcher, times(2)).onChanged(any());
+      verify(resourceWatcher, times(2)).onResourceChanged(argThat(StatusOr::hasValue));
       xdsClient.cancelXdsResourceWatch(
           XdsEndpointResource.getInstance(), serverName, resourceWatcher);
     });

--- a/xds/src/test/java/io/grpc/xds/XdsServerTestHelper.java
+++ b/xds/src/test/java/io/grpc/xds/XdsServerTestHelper.java
@@ -24,6 +24,8 @@ import com.google.common.util.concurrent.SettableFuture;
 import io.envoyproxy.envoy.config.core.v3.SocketAddress.Protocol;
 import io.grpc.InsecureChannelCredentials;
 import io.grpc.MetricRecorder;
+import io.grpc.Status;
+import io.grpc.StatusOr;
 import io.grpc.internal.ObjectPool;
 import io.grpc.xds.EnvoyServerProtoData.ConnectionSourceType;
 import io.grpc.xds.EnvoyServerProtoData.FilterChain;
@@ -295,13 +297,14 @@ public class XdsServerTestHelper {
     void deliverLdsUpdateWithApiListener(long httpMaxStreamDurationNano,
         List<VirtualHost> virtualHosts) {
       execute(() -> {
-        ldsWatcher.onChanged(LdsUpdate.forApiListener(HttpConnectionManager.forVirtualHosts(
-            httpMaxStreamDurationNano, virtualHosts, null)));
+        LdsUpdate update = LdsUpdate.forApiListener(HttpConnectionManager.forVirtualHosts(
+            httpMaxStreamDurationNano, virtualHosts, null));
+        ldsWatcher.onResourceChanged(StatusOr.fromValue(update));
       });
     }
 
     void deliverLdsUpdate(LdsUpdate ldsUpdate) {
-      execute(() -> ldsWatcher.onChanged(ldsUpdate));
+      execute(() -> ldsWatcher.onResourceChanged(StatusOr.fromValue(ldsUpdate)));
     }
 
     void deliverLdsUpdate(
@@ -316,11 +319,14 @@ public class XdsServerTestHelper {
     }
 
     void deliverLdsResourceNotFound() {
-      execute(() -> ldsWatcher.onResourceDoesNotExist(awaitLdsResource(DEFAULT_TIMEOUT)));
+      String resourceName = awaitLdsResource(DEFAULT_TIMEOUT);
+      Status status = Status.NOT_FOUND.withDescription("Resource not found: " + resourceName);
+      execute(() -> ldsWatcher.onResourceChanged(StatusOr.fromStatus(status)));
     }
 
     void deliverRdsUpdate(String resourceName, List<VirtualHost> virtualHosts) {
-      execute(() -> rdsWatchers.get(resourceName).onChanged(new RdsUpdate(virtualHosts)));
+      RdsUpdate update = new RdsUpdate(virtualHosts);
+      execute(() -> rdsWatchers.get(resourceName).onResourceChanged(StatusOr.fromValue(update)));
     }
 
     void deliverRdsUpdate(String resourceName, VirtualHost virtualHost) {
@@ -328,7 +334,8 @@ public class XdsServerTestHelper {
     }
 
     void deliverRdsResourceNotFound(String resourceName) {
-      execute(() -> rdsWatchers.get(resourceName).onResourceDoesNotExist(resourceName));
+      Status status = Status.NOT_FOUND.withDescription("Resource not found: " + resourceName);
+      execute(() -> rdsWatchers.get(resourceName).onResourceChanged(StatusOr.fromStatus(status)));
     }
   }
 }


### PR DESCRIPTION
Implements XdsClient watcher API changes of gRFC A88- https://github.com/grpc/proposal/blob/master/A88-xds-data-error-handling.md

Contents of the specific implemented part of grfc A88:

Changes to XdsClient Watcher APIs
The current XdsClient API has three methods:

OnResourceChanged(ResourceType resource): Invoked whenever a new version of the resource is received from the xDS server.

OnError(Status status): Invoked for all transient errors and for some data errors (NACKs). The watcher is generally expected to ignore the error if it already has a valid cached resource.

OnResourceDoesNotExist(): Invoked specifically for the does-not-exist case. The watcher is generally expected to stop using any previously cached resource and put itself into a failing state.

Note: The mechanism described in [gRFC A53](https://github.com/grpc/proposal/blob/master/A53-xds-ignore-resource-deletion.md) inhibits these notifications for only the case where we already had a cached version of the resource, which in the SotW protocol applies only to LDS and CDS. That mechanism does not affect the case where we do not already have a cached version of the resource, which is where the does-not-exist timer is used.
These methods do not map well to the desired error handling behavior defined above.

This proposal replaces those methods with the following two methods:

OnResourceChanged(StatusOr resource): Will be invoked to notify the watcher of a new version of the resource received from the xDS server or an error indicating the reason why the resource cannot be obtained. Note that if an error is passed to this method after the watcher has previously seen a valid resource, the watcher is expected to stop using that previously delivered resource. In this case, the XdsClient will remove the resource from its cache, so that CSDS (see [gRFC A40](https://github.com/grpc/proposal/blob/master/A40-csds-support.md)) and XdsClient metrics (see [gRFC A78](https://github.com/grpc/proposal/blob/master/A78-grpc-metrics-wrr-pf-xds.md)) will not reflect a resource that the client is not actually using.

OnAmbientError(Status status): Will be invoked to notify the watcher of an error that occurs after a resource has been received that should not modify the watcher's use of that resource but that may be useful information about the ambient state of the XdsClient. In particular, the watcher should not stop using the previously seen resource, and the XdsClient will not remove the resource from its cache. However, the error message may be useful as additional context to include in errors that are being generated for other reasons. For example, if failing a data plane RPC due to all endpoints being unreachable, it may be useful to also report that the client has lost contact with the xDS server. The error condition is considered to be cleared when either OnResourceChanged() is invoked or OnAmbientError() is invoked again with an OK status.