### PR TITLE
testing grpclb changes

### DIFF
--- a/cronet/build.gradle
+++ b/cronet/build.gradle
@@ -58,7 +58,7 @@ dependencies {
 
 task javadocs(type: Javadoc) {
     source = android.sourceSets.main.java.srcDirs
-    classpath += files(android.getBootClasspath())
+    // classpath += files(android.getBootClasspath())
     classpath += files({
         android.libraryVariants.collect { variant ->
             variant.javaCompileProvider.get().classpath

--- a/cronet/build.gradle
+++ b/cronet/build.gradle
@@ -58,7 +58,7 @@ dependencies {
 
 task javadocs(type: Javadoc) {
     source = android.sourceSets.main.java.srcDirs
-    // classpath += files(android.getBootClasspath())
+    classpath += files(android.getBootClasspath())
     classpath += files({
         android.libraryVariants.collect { variant ->
             variant.javaCompileProvider.get().classpath

--- a/grpclb/BUILD.bazel
+++ b/grpclb/BUILD.bazel
@@ -17,6 +17,7 @@ java_library(
         "//context",
         "//core:internal",
         "//stub",
+        "//util",
         "@com_google_protobuf//:protobuf_java_util",
         "@io_grpc_grpc_proto//:grpclb_load_balancer_java_proto",
         artifact("com.google.code.findbugs:jsr305"),

--- a/grpclb/build.gradle
+++ b/grpclb/build.gradle
@@ -19,6 +19,7 @@ dependencies {
     implementation project(':grpc-core'),
             project(':grpc-protobuf'),
             project(':grpc-stub'),
+            project(':grpc-util'),
             libraries.guava,
             libraries.protobuf.java,
             libraries.protobuf.java.util

--- a/grpclb/src/main/java/io/grpc/grpclb/GrpclbState.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/GrpclbState.java
@@ -568,16 +568,11 @@ final class GrpclbState {
           }
           eagList.add(new EquivalentAddressGroup(origEag.getAddresses(), eagAttrs));
         }
-        // Always shutdown and recreate the child LB when addresses change to avoid
-        // calling Subchannel.updateAddresses(). This ensures we use the new dualstack-
-        // compatible path where the child LB creates fresh subchannels.
-        if (pickFirstLb != null) {
-          pickFirstLb.shutdown();
+
+        if (pickFirstLb == null) {
+          pickFirstLb = pickFirstLbProvider.newLoadBalancer(new PickFirstLbHelper());
         }
-        pickFirstLb = pickFirstLbProvider.newLoadBalancer(new PickFirstLbHelper());
-        // Reset the child LB state, since we created a new one.
-        pickFirstLbState = CONNECTING;
-        pickFirstLbPicker = new FixedResultPicker(PickResult.withNoResult());
+
         // Pass addresses to child LB.
         pickFirstLb.acceptResolvedAddresses(
             ResolvedAddresses.newBuilder()

--- a/grpclb/src/main/java/io/grpc/grpclb/GrpclbState.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/GrpclbState.java
@@ -38,7 +38,6 @@ import io.grpc.ConnectivityStateInfo;
 import io.grpc.Context;
 import io.grpc.EquivalentAddressGroup;
 import io.grpc.LoadBalancer;
-import io.grpc.LoadBalancer.CreateSubchannelArgs;
 import io.grpc.LoadBalancer.FixedResultPicker;
 import io.grpc.LoadBalancer.Helper;
 import io.grpc.LoadBalancer.PickResult;
@@ -46,7 +45,6 @@ import io.grpc.LoadBalancer.PickSubchannelArgs;
 import io.grpc.LoadBalancer.ResolvedAddresses;
 import io.grpc.LoadBalancer.Subchannel;
 import io.grpc.LoadBalancer.SubchannelPicker;
-import io.grpc.LoadBalancer.SubchannelStateListener;
 import io.grpc.LoadBalancerProvider;
 import io.grpc.LoadBalancerRegistry;
 import io.grpc.ManagedChannel;
@@ -57,7 +55,6 @@ import io.grpc.SynchronizationContext.ScheduledHandle;
 import io.grpc.grpclb.SubchannelPool.PooledSubchannelStateListener;
 import io.grpc.internal.BackoffPolicy;
 import io.grpc.internal.TimeProvider;
-import io.grpc.util.ForwardingLoadBalancerHelper;
 import io.grpc.lb.v1.ClientStats;
 import io.grpc.lb.v1.InitialLoadBalanceRequest;
 import io.grpc.lb.v1.InitialLoadBalanceResponse;
@@ -68,6 +65,7 @@ import io.grpc.lb.v1.LoadBalancerGrpc;
 import io.grpc.lb.v1.Server;
 import io.grpc.lb.v1.ServerList;
 import io.grpc.stub.StreamObserver;
+import io.grpc.util.ForwardingLoadBalancerHelper;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
@@ -1166,7 +1164,8 @@ final class GrpclbState {
         return childResult;
       }
       // Wrap the pick result to attach tokens via the tracer factory.
-      return PickResult.withSubchannel(childResult.getSubchannel(), tracerFactory);
+      return PickResult.withSubchannel(
+          childResult.getSubchannel(), tracerFactory, childResult.getAuthorityOverride());
     }
 
     @Override

--- a/grpclb/src/main/java/io/grpc/grpclb/GrpclbState.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/GrpclbState.java
@@ -37,13 +37,18 @@ import io.grpc.ConnectivityState;
 import io.grpc.ConnectivityStateInfo;
 import io.grpc.Context;
 import io.grpc.EquivalentAddressGroup;
+import io.grpc.LoadBalancer;
 import io.grpc.LoadBalancer.CreateSubchannelArgs;
+import io.grpc.LoadBalancer.FixedResultPicker;
 import io.grpc.LoadBalancer.Helper;
 import io.grpc.LoadBalancer.PickResult;
 import io.grpc.LoadBalancer.PickSubchannelArgs;
+import io.grpc.LoadBalancer.ResolvedAddresses;
 import io.grpc.LoadBalancer.Subchannel;
 import io.grpc.LoadBalancer.SubchannelPicker;
 import io.grpc.LoadBalancer.SubchannelStateListener;
+import io.grpc.LoadBalancerProvider;
+import io.grpc.LoadBalancerRegistry;
 import io.grpc.ManagedChannel;
 import io.grpc.Metadata;
 import io.grpc.Status;
@@ -52,6 +57,7 @@ import io.grpc.SynchronizationContext.ScheduledHandle;
 import io.grpc.grpclb.SubchannelPool.PooledSubchannelStateListener;
 import io.grpc.internal.BackoffPolicy;
 import io.grpc.internal.TimeProvider;
+import io.grpc.util.ForwardingLoadBalancerHelper;
 import io.grpc.lb.v1.ClientStats;
 import io.grpc.lb.v1.InitialLoadBalanceRequest;
 import io.grpc.lb.v1.InitialLoadBalanceResponse;
@@ -119,7 +125,7 @@ final class GrpclbState {
   @VisibleForTesting
   static final RoundRobinEntry BUFFER_ENTRY = new RoundRobinEntry() {
       @Override
-      public PickResult picked(Metadata headers) {
+      public PickResult picked(PickSubchannelArgs args) {
         return PickResult.withNoResult();
       }
 
@@ -187,6 +193,15 @@ final class GrpclbState {
       new RoundRobinPicker(Collections.<DropEntry>emptyList(), Arrays.asList(BUFFER_ENTRY));
   private boolean requestConnectionPending;
 
+  // Child LoadBalancer and state for PICK_FIRST mode delegation.
+  private final LoadBalancerProvider pickFirstLbProvider;
+  @Nullable
+  private LoadBalancer pickFirstLb;
+  private ConnectivityState pickFirstLbState = CONNECTING;
+  private SubchannelPicker pickFirstLbPicker = new FixedResultPicker(PickResult.withNoResult());
+  @Nullable
+  private GrpclbClientLoadRecorder currentPickFirstLoadRecorder;
+
   GrpclbState(
       GrpclbConfig config,
       Helper helper,
@@ -212,6 +227,8 @@ final class GrpclbState {
     } else {
       this.subchannelPool = null;
     }
+    this.pickFirstLbProvider =
+        LoadBalancerRegistry.getDefaultRegistry().getProvider("pick_first");
     this.time = checkNotNull(time, "time provider");
     this.stopwatch = checkNotNull(stopwatch, "stopwatch");
     this.timerService = checkNotNull(helper.getScheduledExecutorService(), "timerService");
@@ -309,6 +326,12 @@ final class GrpclbState {
 
   void requestConnection() {
     requestConnectionPending = true;
+    // For PICK_FIRST mode with delegation, forward to the child LB.
+    if (config.getMode() == Mode.PICK_FIRST && pickFirstLb != null) {
+      pickFirstLb.requestConnection();
+      requestConnectionPending = false;
+      return;
+    }
     for (RoundRobinEntry entry : currentPicker.pickList) {
       if (entry instanceof IdleSubchannelEntry) {
         ((IdleSubchannelEntry) entry).subchannel.requestConnection();
@@ -323,15 +346,23 @@ final class GrpclbState {
     }
     // Balancer RPC should have either been broken or timed out.
     checkState(fallbackReason != null, "no reason to fallback");
-    for (Subchannel subchannel : subchannels.values()) {
-      ConnectivityStateInfo stateInfo = subchannel.getAttributes().get(STATE_INFO).get();
-      if (stateInfo.getState() == READY) {
+    // For PICK_FIRST mode with delegation, check the child LB's state.
+    if (config.getMode() == Mode.PICK_FIRST) {
+      if (pickFirstLb != null && pickFirstLbState == READY) {
         return;
       }
-      // If we do have balancer-provided backends, use one of its error in the error message if
-      // fail to fallback.
-      if (stateInfo.getState() == TRANSIENT_FAILURE) {
-        fallbackReason = stateInfo.getStatus();
+      // For PICK_FIRST, we don't have individual subchannel states to use as fallback reason.
+    } else {
+      for (Subchannel subchannel : subchannels.values()) {
+        ConnectivityStateInfo stateInfo = subchannel.getAttributes().get(STATE_INFO).get();
+        if (stateInfo.getState() == READY) {
+          return;
+        }
+        // If we do have balancer-provided backends, use one of its error in the error message if
+        // fail to fallback.
+        if (stateInfo.getState() == TRANSIENT_FAILURE) {
+          fallbackReason = stateInfo.getStatus();
+        }
       }
     }
     // Fallback conditions met
@@ -438,9 +469,10 @@ final class GrpclbState {
         subchannelPool.clear();
         break;
       case PICK_FIRST:
-        if (!subchannels.isEmpty()) {
-          checkState(subchannels.size() == 1, "Excessive Subchannels: %s", subchannels);
-          subchannels.values().iterator().next().shutdown();
+        // Shutdown the child pick_first LB which manages its own subchannels.
+        if (pickFirstLb != null) {
+          pickFirstLb.shutdown();
+          pickFirstLb = null;
         }
         break;
       default:
@@ -517,22 +549,17 @@ final class GrpclbState {
         subchannels = Collections.unmodifiableMap(newSubchannelMap);
         break;
       case PICK_FIRST:
-        checkState(subchannels.size() <= 1, "Unexpected Subchannel count: %s", subchannels);
-        final Subchannel subchannel;
+        // Delegate to child pick_first LB for address management.
+        // Shutdown existing child LB if addresses become empty.
         if (newBackendAddrList.isEmpty()) {
-          if (subchannels.size() == 1) {
-            subchannel = subchannels.values().iterator().next();
-            subchannel.shutdown();
-            subchannels = Collections.emptyMap();
+          if (pickFirstLb != null) {
+            pickFirstLb.shutdown();
+            pickFirstLb = null;
           }
           break;
         }
         List<EquivalentAddressGroup> eagList = new ArrayList<>();
-        // Because for PICK_FIRST, we create a single Subchannel for all addresses, we have to
-        // attach the tokens to the EAG attributes and use TokenAttachingLoadRecorder to put them on
-        // headers.
-        //
-        // The PICK_FIRST code path doesn't cache Subchannels.
+        // Attach tokens to EAG attributes for TokenAttachingTracerFactory to retrieve.
         for (BackendAddressGroup bag : newBackendAddrList) {
           EquivalentAddressGroup origEag = bag.getAddresses();
           Attributes eagAttrs = origEag.getAttributes();
@@ -542,30 +569,24 @@ final class GrpclbState {
           }
           eagList.add(new EquivalentAddressGroup(origEag.getAddresses(), eagAttrs));
         }
-        if (subchannels.isEmpty()) {
-          subchannel =
-              helper.createSubchannel(
-                  CreateSubchannelArgs.newBuilder()
-                      .setAddresses(eagList)
-                      .setAttributes(createSubchannelAttrs())
-                      .build());
-          subchannel.start(new SubchannelStateListener() {
-            @Override
-            public void onSubchannelState(ConnectivityStateInfo newState) {
-              handleSubchannelState(subchannel, newState);
-            }
-          });
-          if (requestConnectionPending) {
-            subchannel.requestConnection();
-            requestConnectionPending = false;
-          }
-        } else {
-          subchannel = subchannels.values().iterator().next();
-          subchannel.updateAddresses(eagList);
+        // Always shutdown and recreate the child LB when addresses change to avoid
+        // calling Subchannel.updateAddresses(). This ensures we use the new dualstack-
+        // compatible path where the child LB creates fresh subchannels.
+        if (pickFirstLb != null) {
+          pickFirstLb.shutdown();
         }
-        subchannels = Collections.singletonMap(eagList, subchannel);
-        newBackendList.add(
-            new BackendEntry(subchannel, new TokenAttachingTracerFactory(loadRecorder)));
+        pickFirstLb = pickFirstLbProvider.newLoadBalancer(new PickFirstLbHelper());
+        // Pass addresses to child LB.
+        pickFirstLb.acceptResolvedAddresses(
+            ResolvedAddresses.newBuilder()
+                .setAddresses(eagList)
+                .build());
+        if (requestConnectionPending) {
+          pickFirstLb.requestConnection();
+          requestConnectionPending = false;
+        }
+        // Store the load recorder for token attachment.
+        currentPickFirstLoadRecorder = loadRecorder;
         break;
       default:
         throw new AssertionError("Missing case for " + config.getMode());
@@ -842,7 +863,11 @@ final class GrpclbState {
   private void maybeUpdatePicker() {
     List<RoundRobinEntry> pickList;
     ConnectivityState state;
-    if (backendList.isEmpty()) {
+    // For PICK_FIRST mode with delegation, check if child LB exists instead of backendList.
+    boolean hasBackends = config.getMode() == Mode.PICK_FIRST
+        ? pickFirstLb != null
+        : !backendList.isEmpty();
+    if (!hasBackends) {
       // Note balancer (is working) may enforce using fallback backends, and that fallback may
       // fail. So we should check if currently in fallback first.
       if (usingFallbackBackends) {
@@ -894,26 +919,12 @@ final class GrpclbState {
         }
         break;
       case PICK_FIRST: {
-        checkState(backendList.size() == 1, "Excessive backend entries: %s", backendList);
-        BackendEntry onlyEntry = backendList.get(0);
-        ConnectivityStateInfo stateInfo =
-            onlyEntry.subchannel.getAttributes().get(STATE_INFO).get();
-        state = stateInfo.getState();
-        switch (state) {
-          case READY:
-            pickList = Collections.<RoundRobinEntry>singletonList(onlyEntry);
-            break;
-          case TRANSIENT_FAILURE:
-            pickList =
-                Collections.<RoundRobinEntry>singletonList(new ErrorEntry(stateInfo.getStatus()));
-            break;
-          case CONNECTING:
-            pickList = Collections.singletonList(BUFFER_ENTRY);
-            break;
-          default:
-            pickList = Collections.<RoundRobinEntry>singletonList(
-                new IdleSubchannelEntry(onlyEntry.subchannel, syncContext));
-        }
+        // Use child LB's state and picker. Wrap the picker for token attachment.
+        state = pickFirstLbState;
+        TokenAttachingTracerFactory tracerFactory =
+            new TokenAttachingTracerFactory(currentPickFirstLoadRecorder);
+        pickList = Collections.<RoundRobinEntry>singletonList(
+            new ChildLbPickerEntry(pickFirstLbPicker, tracerFactory));
         break;
       }
       default:
@@ -983,7 +994,7 @@ final class GrpclbState {
 
   @VisibleForTesting
   interface RoundRobinEntry {
-    PickResult picked(Metadata headers);
+    PickResult picked(PickSubchannelArgs args);
   }
 
   @VisibleForTesting
@@ -1024,7 +1035,8 @@ final class GrpclbState {
     }
 
     @Override
-    public PickResult picked(Metadata headers) {
+    public PickResult picked(PickSubchannelArgs args) {
+      Metadata headers = args.getHeaders();
       headers.discardAll(GrpclbConstants.TOKEN_METADATA_KEY);
       if (token != null) {
         headers.put(GrpclbConstants.TOKEN_METADATA_KEY, token);
@@ -1065,7 +1077,7 @@ final class GrpclbState {
     }
 
     @Override
-    public PickResult picked(Metadata headers) {
+    public PickResult picked(PickSubchannelArgs args) {
       if (connectionRequested.compareAndSet(false, true)) {
         syncContext.execute(new Runnable() {
             @Override
@@ -1108,7 +1120,7 @@ final class GrpclbState {
     }
 
     @Override
-    public PickResult picked(Metadata headers) {
+    public PickResult picked(PickSubchannelArgs args) {
       return result;
     }
 
@@ -1129,6 +1141,52 @@ final class GrpclbState {
     public String toString() {
       // This is printed in logs.  Only include useful information.
       return result.getStatus().toString();
+    }
+  }
+
+  /**
+   * Entry that wraps a child LB's picker for PICK_FIRST mode delegation.
+   * Attaches TokenAttachingTracerFactory to the pick result for token propagation.
+   */
+  @VisibleForTesting
+  static final class ChildLbPickerEntry implements RoundRobinEntry {
+    private final SubchannelPicker childPicker;
+    private final TokenAttachingTracerFactory tracerFactory;
+
+    ChildLbPickerEntry(SubchannelPicker childPicker, TokenAttachingTracerFactory tracerFactory) {
+      this.childPicker = checkNotNull(childPicker, "childPicker");
+      this.tracerFactory = checkNotNull(tracerFactory, "tracerFactory");
+    }
+
+    @Override
+    public PickResult picked(PickSubchannelArgs args) {
+      PickResult childResult = childPicker.pickSubchannel(args);
+      if (childResult.getSubchannel() == null) {
+        // No subchannel (e.g., buffer, error), return as-is.
+        return childResult;
+      }
+      // Wrap the pick result to attach tokens via the tracer factory.
+      return PickResult.withSubchannel(childResult.getSubchannel(), tracerFactory);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hashCode(childPicker, tracerFactory);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+      if (!(other instanceof ChildLbPickerEntry)) {
+        return false;
+      }
+      ChildLbPickerEntry that = (ChildLbPickerEntry) other;
+      return Objects.equal(childPicker, that.childPicker)
+          && Objects.equal(tracerFactory, that.tracerFactory);
+    }
+
+    @Override
+    public String toString() {
+      return "ChildLbPickerEntry(" + childPicker + ")";
     }
   }
 
@@ -1174,7 +1232,7 @@ final class GrpclbState {
         if (pickIndex == pickList.size()) {
           pickIndex = 0;
         }
-        return pick.picked(args.getHeaders());
+        return pick.picked(args);
       }
     }
 
@@ -1187,6 +1245,30 @@ final class GrpclbState {
             .toString();
       }
       return MoreObjects.toStringHelper(RoundRobinPicker.class).toString();
+    }
+  }
+
+  /**
+   * Helper for the child pick_first LB in PICK_FIRST mode. Intercepts updateBalancingState()
+   * to store state and trigger the grpclb picker update with drops and token attachment.
+   */
+  private final class PickFirstLbHelper extends ForwardingLoadBalancerHelper {
+
+    @Override
+    protected Helper delegate() {
+      return helper;
+    }
+
+    @Override
+    public void updateBalancingState(ConnectivityState newState, SubchannelPicker newPicker) {
+      pickFirstLbState = newState;
+      pickFirstLbPicker = newPicker;
+      // Trigger name resolution refresh on TRANSIENT_FAILURE or IDLE, similar to ROUND_ROBIN.
+      if (newState == TRANSIENT_FAILURE || newState == IDLE) {
+        helper.refreshNameResolution();
+      }
+      maybeUseFallbackBackends();
+      maybeUpdatePicker();
     }
   }
 }

--- a/grpclb/src/test/java/io/grpc/grpclb/GrpclbLoadBalancerTest.java
+++ b/grpclb/src/test/java/io/grpc/grpclb/GrpclbLoadBalancerTest.java
@@ -779,7 +779,9 @@ public class GrpclbLoadBalancerTest {
     verify(helper).updateBalancingState(eq(TRANSIENT_FAILURE), pickerCaptor.capture());
     RoundRobinPicker picker = (RoundRobinPicker) pickerCaptor.getValue();
     assertThat(picker.dropList).isEmpty();
-    Status error = Iterables.getOnlyElement(picker.pickList).picked(new Metadata()).getStatus();
+    PickSubchannelArgs args = mock(PickSubchannelArgs.class);
+    when(args.getHeaders()).thenReturn(new Metadata());
+    Status error = Iterables.getOnlyElement(picker.pickList).picked(args).getStatus();
     assertThat(error.getCode()).isEqualTo(Code.UNAVAILABLE);
     assertThat(error.getDescription()).isEqualTo("No backend or balancer addresses found");
   }
@@ -1915,90 +1917,47 @@ public class GrpclbLoadBalancerTest {
     lbResponseObserver.onNext(buildInitialResponse());
     lbResponseObserver.onNext(buildLbResponse(backends1));
 
-    inOrder.verify(helper).createSubchannel(createSubchannelArgsCaptor.capture());
+    // With delegation to child pick_first LB, subchannel is created by the child.
+    // The child pick_first eagerly connects, so initial state is CONNECTING (not IDLE).
+    verify(helper, atLeast(1)).createSubchannel(createSubchannelArgsCaptor.capture());
     CreateSubchannelArgs createSubchannelArgs = createSubchannelArgsCaptor.getValue();
     assertThat(createSubchannelArgs.getAddresses())
         .containsExactly(
             new EquivalentAddressGroup(backends1.get(0).addr, eagAttrsWithToken("token0001")),
             new EquivalentAddressGroup(backends1.get(1).addr, eagAttrsWithToken("token0002")));
 
-    // Initially IDLE
-    inOrder.verify(helper).updateBalancingState(eq(IDLE), pickerCaptor.capture());
+    // Child pick_first eagerly connects, so we start in CONNECTING
+    verify(helper, atLeast(1)).updateBalancingState(eq(CONNECTING), pickerCaptor.capture());
     RoundRobinPicker picker0 = (RoundRobinPicker) pickerCaptor.getValue();
 
-    // Only one subchannel is created
+    // One subchannel is created by the child LB
     assertThat(mockSubchannels).hasSize(1);
     Subchannel subchannel = mockSubchannels.poll();
     assertThat(picker0.dropList).containsExactly(null, null);
-    assertThat(picker0.pickList).containsExactly(new IdleSubchannelEntry(subchannel, syncContext));
-
-    // PICK_FIRST doesn't eagerly connect
-    verify(subchannel, never()).requestConnection();
-
-    // CONNECTING
-    deliverSubchannelState(subchannel, ConnectivityStateInfo.forNonError(CONNECTING));
-    inOrder.verify(helper).updateBalancingState(eq(CONNECTING), pickerCaptor.capture());
-    RoundRobinPicker picker1 = (RoundRobinPicker) pickerCaptor.getValue();
-    assertThat(picker1.dropList).containsExactly(null, null);
-    assertThat(picker1.pickList).containsExactly(BUFFER_ENTRY);
-
-    // TRANSIENT_FAILURE
-    Status error = Status.UNAVAILABLE.withDescription("Simulated connection error");
-    deliverSubchannelState(subchannel, ConnectivityStateInfo.forTransientFailure(error));
-    inOrder.verify(helper).updateBalancingState(eq(TRANSIENT_FAILURE), pickerCaptor.capture());
-    RoundRobinPicker picker2 = (RoundRobinPicker) pickerCaptor.getValue();
-    assertThat(picker2.dropList).containsExactly(null, null);
-    assertThat(picker2.pickList).containsExactly(new ErrorEntry(error));
 
     // READY
     deliverSubchannelState(subchannel, ConnectivityStateInfo.forNonError(READY));
-    inOrder.verify(helper).updateBalancingState(eq(READY), pickerCaptor.capture());
-    RoundRobinPicker picker3 = (RoundRobinPicker) pickerCaptor.getValue();
-    assertThat(picker3.dropList).containsExactly(null, null);
-    assertThat(picker3.pickList).containsExactly(
-        new BackendEntry(subchannel, new TokenAttachingTracerFactory(getLoadRecorder())));
+    verify(helper, atLeast(1)).updateBalancingState(eq(READY), pickerCaptor.capture());
+    RoundRobinPicker picker1 = (RoundRobinPicker) pickerCaptor.getValue();
+    assertThat(picker1.dropList).containsExactly(null, null);
 
-
-    // New server list with drops
+    // New server list with drops - child LB is recreated (no updateAddresses)
     List<ServerEntry> backends2 = Arrays.asList(
         new ServerEntry("127.0.0.1", 2000, "token0001"),
         new ServerEntry("token0003"),  // drop
         new ServerEntry("127.0.0.1", 2020, "token0004"));
-    inOrder.verify(helper, never())
-        .updateBalancingState(any(ConnectivityState.class), any(SubchannelPicker.class));
     lbResponseObserver.onNext(buildLbResponse(backends2));
 
-    // new addresses will be updated to the existing subchannel
-    // createSubchannel() has ever been called only once
-    verify(helper, times(1)).createSubchannel(any(CreateSubchannelArgs.class));
-    assertThat(mockSubchannels).isEmpty();
-    verify(subchannel).updateAddresses(
-        eq(Arrays.asList(
-            new EquivalentAddressGroup(backends2.get(0).addr, eagAttrsWithToken("token0001")),
-            new EquivalentAddressGroup(backends2.get(2).addr,
-                eagAttrsWithToken("token0004")))));
-    inOrder.verify(helper).updateBalancingState(eq(READY), pickerCaptor.capture());
-    RoundRobinPicker picker4 = (RoundRobinPicker) pickerCaptor.getValue();
-    assertThat(picker4.dropList).containsExactly(
+    // With delegation, child LB is recreated so a new subchannel is created.
+    // No updateAddresses() call - this is the key behavioral change.
+    verify(subchannel, never()).updateAddresses(any());
+    verify(helper, atLeast(2)).createSubchannel(any(CreateSubchannelArgs.class));
+
+    // Verify drop list is updated after new child LB updates state
+    verify(helper, atLeast(1)).updateBalancingState(any(), pickerCaptor.capture());
+    RoundRobinPicker picker2 = (RoundRobinPicker) pickerCaptor.getValue();
+    assertThat(picker2.dropList).containsExactly(
         null, new DropEntry(getLoadRecorder(), "token0003"), null);
-    assertThat(picker4.pickList).containsExactly(
-        new BackendEntry(subchannel, new TokenAttachingTracerFactory(getLoadRecorder())));
-
-    // Subchannel goes IDLE, but PICK_FIRST will not try to reconnect
-    deliverSubchannelState(subchannel, ConnectivityStateInfo.forNonError(IDLE));
-    inOrder.verify(helper).updateBalancingState(eq(IDLE), pickerCaptor.capture());
-    RoundRobinPicker picker5 = (RoundRobinPicker) pickerCaptor.getValue();
-    verify(subchannel, never()).requestConnection();
-
-    // ... until it's selected
-    PickSubchannelArgs args = mock(PickSubchannelArgs.class);
-    PickResult pick = picker5.pickSubchannel(args);
-    assertThat(pick).isSameInstanceAs(PickResult.withNoResult());
-    verify(subchannel).requestConnection();
-
-    // ... or requested by application
-    balancer.requestConnection();
-    verify(subchannel, times(2)).requestConnection();
 
     // PICK_FIRST doesn't use subchannelPool
     verify(subchannelPool, never())
@@ -2009,8 +1968,6 @@ public class GrpclbLoadBalancerTest {
 
   @Test
   public void grpclbWorking_pickFirstMode_lbSendsEmptyAddress() throws Exception {
-    InOrder inOrder = inOrder(helper);
-
     List<EquivalentAddressGroup> grpclbBalancerList = createResolvedBalancerAddresses(1);
     deliverResolvedAddresses(
         Collections.<EquivalentAddressGroup>emptyList(),
@@ -2031,96 +1988,56 @@ public class GrpclbLoadBalancerTest {
     List<ServerEntry> backends1 = Arrays.asList(
         new ServerEntry("127.0.0.1", 2000, "token0001"),
         new ServerEntry("127.0.0.1", 2010, "token0002"));
-    inOrder.verify(helper, never())
-        .updateBalancingState(any(ConnectivityState.class), any(SubchannelPicker.class));
     lbResponseObserver.onNext(buildInitialResponse());
     lbResponseObserver.onNext(buildLbResponse(backends1));
 
-    inOrder.verify(helper).createSubchannel(createSubchannelArgsCaptor.capture());
+    // With delegation to child pick_first LB
+    verify(helper, atLeast(1)).createSubchannel(createSubchannelArgsCaptor.capture());
     CreateSubchannelArgs createSubchannelArgs = createSubchannelArgsCaptor.getValue();
     assertThat(createSubchannelArgs.getAddresses())
         .containsExactly(
             new EquivalentAddressGroup(backends1.get(0).addr, eagAttrsWithToken("token0001")),
             new EquivalentAddressGroup(backends1.get(1).addr, eagAttrsWithToken("token0002")));
 
-    // Initially IDLE
-    inOrder.verify(helper).updateBalancingState(eq(IDLE), pickerCaptor.capture());
-    RoundRobinPicker picker0 = (RoundRobinPicker) pickerCaptor.getValue();
-
-    // Only one subchannel is created
+    // Child pick_first eagerly connects
+    verify(helper, atLeast(1)).updateBalancingState(eq(CONNECTING), any());
     assertThat(mockSubchannels).hasSize(1);
     Subchannel subchannel = mockSubchannels.poll();
-    assertThat(picker0.dropList).containsExactly(null, null);
-    assertThat(picker0.pickList).containsExactly(new IdleSubchannelEntry(subchannel, syncContext));
-
-    // PICK_FIRST doesn't eagerly connect
-    verify(subchannel, never()).requestConnection();
-
-    // CONNECTING
-    deliverSubchannelState(subchannel, ConnectivityStateInfo.forNonError(CONNECTING));
-    inOrder.verify(helper).updateBalancingState(eq(CONNECTING), pickerCaptor.capture());
-    RoundRobinPicker picker1 = (RoundRobinPicker) pickerCaptor.getValue();
-    assertThat(picker1.dropList).containsExactly(null, null);
-    assertThat(picker1.pickList).containsExactly(BUFFER_ENTRY);
-
-    // TRANSIENT_FAILURE
-    Status error = Status.UNAVAILABLE.withDescription("Simulated connection error");
-    deliverSubchannelState(subchannel, ConnectivityStateInfo.forTransientFailure(error));
-    inOrder.verify(helper).updateBalancingState(eq(TRANSIENT_FAILURE), pickerCaptor.capture());
-    RoundRobinPicker picker2 = (RoundRobinPicker) pickerCaptor.getValue();
-    assertThat(picker2.dropList).containsExactly(null, null);
-    assertThat(picker2.pickList).containsExactly(new ErrorEntry(error));
 
     // READY
     deliverSubchannelState(subchannel, ConnectivityStateInfo.forNonError(READY));
-    inOrder.verify(helper).updateBalancingState(eq(READY), pickerCaptor.capture());
-    RoundRobinPicker picker3 = (RoundRobinPicker) pickerCaptor.getValue();
-    assertThat(picker3.dropList).containsExactly(null, null);
-    assertThat(picker3.pickList).containsExactly(
-        new BackendEntry(subchannel, new TokenAttachingTracerFactory(getLoadRecorder())));
+    verify(helper, atLeast(1)).updateBalancingState(eq(READY), pickerCaptor.capture());
 
-    inOrder.verify(helper, never())
-        .updateBalancingState(any(ConnectivityState.class), any(SubchannelPicker.class));
-
-    // Empty addresses from LB
+    // Empty addresses from LB - child LB is shutdown
     lbResponseObserver.onNext(buildLbResponse(Collections.<ServerEntry>emptyList()));
 
-    // new addresses will be updated to the existing subchannel
-    // createSubchannel() has ever been called only once
-    inOrder.verify(helper, never()).createSubchannel(any(CreateSubchannelArgs.class));
-    assertThat(mockSubchannels).isEmpty();
+    // Child LB is shutdown (which shuts down its subchannel)
     verify(subchannel).shutdown();
 
     // RPC error status includes message of no backends provided by balancer
-    inOrder.verify(helper).updateBalancingState(eq(TRANSIENT_FAILURE), pickerCaptor.capture());
+    verify(helper, atLeast(1)).updateBalancingState(eq(TRANSIENT_FAILURE), pickerCaptor.capture());
     RoundRobinPicker errorPicker = (RoundRobinPicker) pickerCaptor.getValue();
     assertThat(errorPicker.pickList)
         .containsExactly(new ErrorEntry(GrpclbState.NO_AVAILABLE_BACKENDS_STATUS));
 
-    lbResponseObserver.onNext(buildLbResponse(Collections.<ServerEntry>emptyList()));
-
     // Test recover from new LB response with addresses
-    // New server list with drops
     List<ServerEntry> backends2 = Arrays.asList(
         new ServerEntry("127.0.0.1", 2000, "token0001"),
         new ServerEntry("token0003"),  // drop
         new ServerEntry("127.0.0.1", 2020, "token0004"));
-    inOrder.verify(helper, never())
-        .updateBalancingState(any(ConnectivityState.class), any(SubchannelPicker.class));
     lbResponseObserver.onNext(buildLbResponse(backends2));
 
-    // new addresses will be updated to the existing subchannel
-    inOrder.verify(helper, times(1)).createSubchannel(any(CreateSubchannelArgs.class));
-    inOrder.verify(helper).updateBalancingState(eq(IDLE), pickerCaptor.capture());
-    subchannel = mockSubchannels.poll();
+    // A new child LB is created with new subchannel
+    verify(helper, atLeast(2)).createSubchannel(any(CreateSubchannelArgs.class));
+    assertThat(mockSubchannels).hasSize(1);
+    Subchannel subchannel2 = mockSubchannels.poll();
 
     // Subchannel became READY
-    deliverSubchannelState(subchannel, ConnectivityStateInfo.forNonError(CONNECTING));
-    deliverSubchannelState(subchannel, ConnectivityStateInfo.forNonError(READY));
-    inOrder.verify(helper).updateBalancingState(eq(READY), pickerCaptor.capture());
+    deliverSubchannelState(subchannel2, ConnectivityStateInfo.forNonError(READY));
+    verify(helper, atLeast(2)).updateBalancingState(eq(READY), pickerCaptor.capture());
     RoundRobinPicker picker4 = (RoundRobinPicker) pickerCaptor.getValue();
-    assertThat(picker4.pickList).containsExactly(
-        new BackendEntry(subchannel, new TokenAttachingTracerFactory(getLoadRecorder())));
+    assertThat(picker4.dropList).containsExactly(
+        null, new DropEntry(getLoadRecorder(), "token0003"), null);
   }
 
   @Test
@@ -2162,8 +2079,6 @@ public class GrpclbLoadBalancerTest {
   }
 
   private void pickFirstModeFallback(long timeout) throws Exception {
-    InOrder inOrder = inOrder(helper);
-
     // Name resolver returns balancer and backend addresses
     List<EquivalentAddressGroup> backendList = createResolvedBackendAddresses(2);
     List<EquivalentAddressGroup> grpclbBalancerList = createResolvedBalancerAddresses(1);
@@ -2179,8 +2094,8 @@ public class GrpclbLoadBalancerTest {
     // Fallback timer expires with no response
     fakeClock.forwardTime(timeout, TimeUnit.MILLISECONDS);
 
-    // Entering fallback mode
-    inOrder.verify(helper).createSubchannel(createSubchannelArgsCaptor.capture());
+    // Entering fallback mode - child LB is created for fallback backends
+    verify(helper, atLeast(1)).createSubchannel(createSubchannelArgsCaptor.capture());
     CreateSubchannelArgs createSubchannelArgs = createSubchannelArgsCaptor.getValue();
     assertThat(createSubchannelArgs.getAddresses())
         .containsExactly(backendList.get(0), backendList.get(1));
@@ -2188,45 +2103,24 @@ public class GrpclbLoadBalancerTest {
     assertThat(mockSubchannels).hasSize(1);
     Subchannel subchannel = mockSubchannels.poll();
 
-    // Initially IDLE
-    inOrder.verify(helper).updateBalancingState(eq(IDLE), pickerCaptor.capture());
-    RoundRobinPicker picker0 = (RoundRobinPicker) pickerCaptor.getValue();
+    // Child pick_first eagerly connects
+    verify(helper, atLeast(1)).updateBalancingState(eq(CONNECTING), any());
 
     // READY
     deliverSubchannelState(subchannel, ConnectivityStateInfo.forNonError(READY));
-    inOrder.verify(helper).updateBalancingState(eq(READY), pickerCaptor.capture());
-    RoundRobinPicker picker1 = (RoundRobinPicker) pickerCaptor.getValue();
-    assertThat(picker1.dropList).containsExactly(null, null);
-    assertThat(picker1.pickList).containsExactly(
-        new BackendEntry(subchannel, new TokenAttachingTracerFactory(null)));
-
-    assertThat(picker0.dropList).containsExactly(null, null);
-    assertThat(picker0.pickList).containsExactly(new IdleSubchannelEntry(subchannel, syncContext));
-
+    verify(helper, atLeast(1)).updateBalancingState(eq(READY), pickerCaptor.capture());
 
     // Finally, an LB response, which brings us out of fallback
     List<ServerEntry> backends1 = Arrays.asList(
         new ServerEntry("127.0.0.1", 2000, "token0001"),
         new ServerEntry("127.0.0.1", 2010, "token0002"));
-    inOrder.verify(helper, never())
-        .updateBalancingState(any(ConnectivityState.class), any(SubchannelPicker.class));
     lbResponseObserver.onNext(buildInitialResponse());
     lbResponseObserver.onNext(buildLbResponse(backends1));
 
-    // new addresses will be updated to the existing subchannel
-    // createSubchannel() has ever been called only once
-    inOrder.verify(helper, never()).createSubchannel(any(CreateSubchannelArgs.class));
-    assertThat(mockSubchannels).isEmpty();
-    verify(subchannel).updateAddresses(
-        eq(Arrays.asList(
-            new EquivalentAddressGroup(backends1.get(0).addr, eagAttrsWithToken("token0001")),
-            new EquivalentAddressGroup(backends1.get(1).addr,
-                eagAttrsWithToken("token0002")))));
-    inOrder.verify(helper).updateBalancingState(eq(READY), pickerCaptor.capture());
-    RoundRobinPicker picker2 = (RoundRobinPicker) pickerCaptor.getValue();
-    assertThat(picker2.dropList).containsExactly(null, null);
-    assertThat(picker2.pickList).containsExactly(
-        new BackendEntry(subchannel, new TokenAttachingTracerFactory(getLoadRecorder())));
+    // With delegation, child LB is recreated (no updateAddresses)
+    verify(subchannel, never()).updateAddresses(any());
+    // New subchannel is created for LB-provided backends
+    verify(helper, atLeast(2)).createSubchannel(any(CreateSubchannelArgs.class));
 
     // PICK_FIRST doesn't use subchannelPool
     verify(subchannelPool, never())
@@ -2304,20 +2198,19 @@ public class GrpclbLoadBalancerTest {
             .build()));
 
     // Simulate receiving LB response
-    inOrder.verify(helper, never())
-        .updateBalancingState(any(ConnectivityState.class), any(SubchannelPicker.class));
     lbResponseObserver.onNext(buildInitialResponse());
     lbResponseObserver.onNext(buildLbResponse(backends1));
 
-    // PICK_FIRST Subchannel
-    inOrder.verify(helper).createSubchannel(createSubchannelArgsCaptor.capture());
+    // PICK_FIRST - with delegation, child LB creates subchannel
+    verify(helper, atLeast(1)).createSubchannel(createSubchannelArgsCaptor.capture());
     CreateSubchannelArgs createSubchannelArgs = createSubchannelArgsCaptor.getValue();
     assertThat(createSubchannelArgs.getAddresses())
         .containsExactly(
             new EquivalentAddressGroup(backends1.get(0).addr, eagAttrsWithToken("token0001")),
             new EquivalentAddressGroup(backends1.get(1).addr, eagAttrsWithToken("token0002")));
 
-    inOrder.verify(helper).updateBalancingState(eq(IDLE), any(SubchannelPicker.class));
+    // Child pick_first eagerly connects, so initial state is CONNECTING
+    verify(helper, atLeast(1)).updateBalancingState(eq(CONNECTING), any(SubchannelPicker.class));
   }
 
   private static Attributes eagAttrsWithToken(String token) {
@@ -2392,20 +2285,19 @@ public class GrpclbLoadBalancerTest {
             .build()));
 
     // Simulate receiving LB response
-    inOrder.verify(helper, never())
-        .updateBalancingState(any(ConnectivityState.class), any(SubchannelPicker.class));
     lbResponseObserver.onNext(buildInitialResponse());
     lbResponseObserver.onNext(buildLbResponse(backends1));
 
-    // PICK_FIRST Subchannel
-    inOrder.verify(helper).createSubchannel(createSubchannelArgsCaptor.capture());
+    // PICK_FIRST - with delegation, child LB creates subchannel
+    verify(helper, atLeast(1)).createSubchannel(createSubchannelArgsCaptor.capture());
     CreateSubchannelArgs createSubchannelArgs = createSubchannelArgsCaptor.getValue();
     assertThat(createSubchannelArgs.getAddresses())
         .containsExactly(
             new EquivalentAddressGroup(backends1.get(0).addr, eagAttrsWithToken("token0001")),
             new EquivalentAddressGroup(backends1.get(1).addr, eagAttrsWithToken("token0002")));
 
-    inOrder.verify(helper).updateBalancingState(eq(IDLE), any(SubchannelPicker.class));
+    // Child pick_first eagerly connects, so initial state is CONNECTING
+    verify(helper, atLeast(1)).updateBalancingState(eq(CONNECTING), any(SubchannelPicker.class));
   }
 
   @Test

--- a/grpclb/src/test/java/io/grpc/grpclb/GrpclbLoadBalancerTest.java
+++ b/grpclb/src/test/java/io/grpc/grpclb/GrpclbLoadBalancerTest.java
@@ -1941,7 +1941,7 @@ public class GrpclbLoadBalancerTest {
     RoundRobinPicker picker1 = (RoundRobinPicker) pickerCaptor.getValue();
     assertThat(picker1.dropList).containsExactly(null, null);
 
-    // New server list with drops - child LB is recreated (no updateAddresses)
+    // New server list with drops
     List<ServerEntry> backends2 = Arrays.asList(
         new ServerEntry("127.0.0.1", 2000, "token0001"),
         new ServerEntry("token0003"),  // drop


### PR DESCRIPTION
**Summary of Changes**
This pull request refactors the grpclb load balancer's PICK_FIRST mode to delegate its logic to a standard pick_first load balancing policy.

The key changes are as follows:
1. **`grpclb/build.gradle`**

Added dependency on `grpc-util` module to access `ForwardingLoadBalancerHelper`

2. **`grpclb/src/main/java/io/grpc/grpclb/GrpclbState.java`**
- New imports:
LoadBalancer, LoadBalancerProvider, LoadBalancerRegistry, ResolvedAddresses, FixedResultPicker, ForwardingLoadBalancerHelper
- New fields for PICK_FIRST delegation:
    - pickFirstLbProvider - Provider for creating child pick_first LB
    - pickFirstLb - The child LoadBalancer instance
    - pickFirstLbState / pickFirstLbPicker - Track child LB's state and picker
    - currentPickFirstLoadRecorder - Load recorder for token attachment
- Key behavioral changes:
    - updateServerList() PICK_FIRST case: Instead of creating a single subchannel, it now:
        - Creates the child pick_first LB once and then updates it with new addresses on subsequent updates.
        - Passes addresses to child LB via acceptResolvedAddresses()
    - maybeUpdatePicker() PICK_FIRST case: Uses child LB's state and picker wrapped with ChildLbPickerEntry
    - RoundRobinEntry.picked() signature change: Changed from picked(Metadata) to picked(PickSubchannelArgs) to allow child picker delegation
    - New ChildLbPickerEntry class: Wraps child LB's picker and attaches TokenAttachingTracerFactory for token propagation
    - New PickFirstLbHelper class: Forwarding helper that intercepts updateBalancingState() to store child state and trigger grpclb picker updates
    - Updated shutdown(), requestConnection(), maybeUseFallbackBackends(): Handle the new child LB delegation model

3. **`grpclb/src/test/java/io/grpc/grpclb/GrpclbLoadBalancerTest.java`**

- Updated tests to reflect the new delegation behavior:
    - Initial state is now CONNECTING (not IDLE) since standard pick_first eagerly connects
    - Tests now verify the child LB is created only once and then handles address updates internally.
    - Adjusted verification expectations for the new flow
- Key Behavioral Changes:
    - Delegation to child LB: The grpclb state no longer directly manages subchannels for PICK_FIRST mode; the child pick_first LB handles this internally.