### PR TITLE
xds: disable priority LB child policy retention cache

### DIFF
--- a/xds/src/main/java/io/grpc/xds/PriorityLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/PriorityLoadBalancer.java
@@ -28,6 +28,7 @@ import io.grpc.LoadBalancer;
 import io.grpc.Status;
 import io.grpc.SynchronizationContext;
 import io.grpc.SynchronizationContext.ScheduledHandle;
+import io.grpc.internal.GrpcUtil;
 import io.grpc.util.ForwardingLoadBalancerHelper;
 import io.grpc.util.GracefulSwitchLoadBalancer;
 import io.grpc.xds.PriorityLoadBalancerProvider.PriorityLbConfig;
@@ -98,7 +99,12 @@ final class PriorityLoadBalancer extends LoadBalancer {
       if (!prioritySet.contains(priority)) {
         ChildLbState childLbState = children.get(priority);
         if (childLbState != null) {
-          childLbState.deactivate();
+          if (GrpcUtil.getFlag("GRPC_EXPERIMENTAL_ENABLE_PRIORITY_LB_CHILD_POLICY_CACHE", false)) {
+            childLbState.deactivate();
+          } else {
+            children.remove(priority);
+            childLbState.tearDown();
+          }
         }
       }
     }

--- a/xds/src/test/java/io/grpc/xds/PriorityLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/PriorityLoadBalancerTest.java
@@ -149,6 +149,105 @@ public class PriorityLoadBalancerTest {
 
   @Test
   public void acceptResolvedAddresses() {
+    System.setProperty("GRPC_EXPERIMENTAL_ENABLE_PRIORITY_LB_CHILD_POLICY_CACHE", "true");
+    try {
+      SocketAddress socketAddress = new InetSocketAddress(8080);
+      EquivalentAddressGroup eag = new EquivalentAddressGroup(socketAddress);
+      eag = AddressFilter.setPathFilter(eag, ImmutableList.of("p1"));
+      List<EquivalentAddressGroup> addresses = ImmutableList.of(eag);
+      Attributes attributes =
+          Attributes.newBuilder().set(Attributes.Key.create("fakeKey"), "fakeValue").build();
+      Object fooConfig0 = new Object();
+      PriorityChildConfig priorityChildConfig0 =
+          new PriorityChildConfig(newChildConfig(fooLbProvider, fooConfig0), true);
+      Object barConfig0 = new Object();
+      PriorityChildConfig priorityChildConfig1 =
+          new PriorityChildConfig(newChildConfig(barLbProvider, barConfig0), true);
+      Object fooConfig1 = new Object();
+      PriorityChildConfig priorityChildConfig2 =
+          new PriorityChildConfig(newChildConfig(fooLbProvider, fooConfig1), true);
+      PriorityLbConfig priorityLbConfig =
+          new PriorityLbConfig(
+              ImmutableMap.of("p0", priorityChildConfig0, "p1", priorityChildConfig1,
+                  "p2", priorityChildConfig2),
+              ImmutableList.of("p0", "p1", "p2"));
+      Status status = priorityLb.acceptResolvedAddresses(
+          ResolvedAddresses.newBuilder()
+              .setAddresses(addresses)
+              .setAttributes(attributes)
+              .setLoadBalancingPolicyConfig(priorityLbConfig)
+              .build());
+      assertThat(status.getCode()).isEqualTo(Status.Code.OK);
+      assertThat(fooBalancers).hasSize(1);
+      assertThat(barBalancers).isEmpty();
+      LoadBalancer fooBalancer0 = Iterables.getOnlyElement(fooBalancers);
+      verify(fooBalancer0).acceptResolvedAddresses(resolvedAddressesCaptor.capture());
+      ResolvedAddresses addressesReceived = resolvedAddressesCaptor.getValue();
+      assertThat(addressesReceived.getAddresses()).isEmpty();
+      assertThat(addressesReceived.getAttributes()).isEqualTo(attributes);
+      assertThat(addressesReceived.getLoadBalancingPolicyConfig()).isEqualTo(fooConfig0);
+
+      // Fail over to p1.
+      fakeClock.forwardTime(10, TimeUnit.SECONDS);
+      assertThat(fooBalancers).hasSize(1);
+      assertThat(barBalancers).hasSize(1);
+      LoadBalancer barBalancer0 = Iterables.getOnlyElement(barBalancers);
+      verify(barBalancer0).acceptResolvedAddresses(resolvedAddressesCaptor.capture());
+      addressesReceived = resolvedAddressesCaptor.getValue();
+      assertThat(Iterables.getOnlyElement(addressesReceived.getAddresses()).getAddresses())
+          .containsExactly(socketAddress);
+      assertThat(addressesReceived.getAttributes()).isEqualTo(attributes);
+      assertThat(addressesReceived.getLoadBalancingPolicyConfig()).isEqualTo(barConfig0);
+
+      // Fail over to p2.
+      fakeClock.forwardTime(10, TimeUnit.SECONDS);
+      assertThat(fooBalancers).hasSize(2);
+      assertThat(barBalancers).hasSize(1);
+      LoadBalancer fooBalancer1 = Iterables.getLast(fooBalancers);
+      verify(fooBalancer1).acceptResolvedAddresses(resolvedAddressesCaptor.capture());
+      addressesReceived = resolvedAddressesCaptor.getValue();
+      assertThat(addressesReceived.getAddresses()).isEmpty();
+      assertThat(addressesReceived.getAttributes()).isEqualTo(attributes);
+      assertThat(addressesReceived.getLoadBalancingPolicyConfig()).isEqualTo(fooConfig1);
+
+      // New update: p0 and p2 deleted; p1 config changed.
+      SocketAddress newSocketAddress = new InetSocketAddress(8081);
+      EquivalentAddressGroup newEag = new EquivalentAddressGroup(newSocketAddress);
+      newEag = AddressFilter.setPathFilter(newEag, ImmutableList.of("p1"));
+      List<EquivalentAddressGroup> newAddresses = ImmutableList.of(newEag);
+      Object newBarConfig = new Object();
+      PriorityLbConfig newPriorityLbConfig =
+          new PriorityLbConfig(
+              ImmutableMap.of("p1",
+                  new PriorityChildConfig(newChildConfig(barLbProvider, newBarConfig), true)),
+              ImmutableList.of("p1"));
+      status = priorityLb.acceptResolvedAddresses(
+          ResolvedAddresses.newBuilder()
+              .setAddresses(newAddresses)
+              .setLoadBalancingPolicyConfig(newPriorityLbConfig)
+              .build());
+      assertThat(status.getCode()).isEqualTo(Status.Code.OK);
+      assertThat(fooBalancers).hasSize(2);
+      assertThat(barBalancers).hasSize(1);
+      verify(barBalancer0, times(2)).acceptResolvedAddresses(resolvedAddressesCaptor.capture());
+      addressesReceived = resolvedAddressesCaptor.getValue();
+      assertThat(Iterables.getOnlyElement(addressesReceived.getAddresses()).getAddresses())
+          .containsExactly(newSocketAddress);
+      assertThat(addressesReceived.getAttributes()).isEqualTo(Attributes.EMPTY);
+      assertThat(addressesReceived.getLoadBalancingPolicyConfig()).isEqualTo(newBarConfig);
+      verify(fooBalancer0, never()).shutdown();
+      verify(fooBalancer1, never()).shutdown();
+      fakeClock.forwardTime(15, TimeUnit.MINUTES);
+      verify(fooBalancer0).shutdown();
+      verify(fooBalancer1).shutdown();
+      verify(barBalancer0, never()).shutdown();
+    } finally {
+      System.clearProperty("GRPC_EXPERIMENTAL_ENABLE_PRIORITY_LB_CHILD_POLICY_CACHE");
+    }
+  }
+
+  @Test
+  public void acceptResolvedAddresses_cacheDisabled() {
     SocketAddress socketAddress = new InetSocketAddress(8080);
     EquivalentAddressGroup eag = new EquivalentAddressGroup(socketAddress);
     eag = AddressFilter.setPathFilter(eag, ImmutableList.of("p1"));
@@ -233,9 +332,6 @@ public class PriorityLoadBalancerTest {
         .containsExactly(newSocketAddress);
     assertThat(addressesReceived.getAttributes()).isEqualTo(Attributes.EMPTY);
     assertThat(addressesReceived.getLoadBalancingPolicyConfig()).isEqualTo(newBarConfig);
-    verify(fooBalancer0, never()).shutdown();
-    verify(fooBalancer1, never()).shutdown();
-    fakeClock.forwardTime(15, TimeUnit.MINUTES);
     verify(fooBalancer0).shutdown();
     verify(fooBalancer1).shutdown();
     verify(barBalancer0, never()).shutdown();
@@ -297,41 +393,46 @@ public class PriorityLoadBalancerTest {
 
   @Test
   public void handleNameResolutionError() {
-    Object fooConfig0 = new Object();
-    PriorityChildConfig priorityChildConfig0 =
-        new PriorityChildConfig(newChildConfig(fooLbProvider, fooConfig0), true);
-    Object fooConfig1 = new Object();
-    PriorityChildConfig priorityChildConfig1 =
-        new PriorityChildConfig(newChildConfig(fooLbProvider, fooConfig1), true);
+    System.setProperty("GRPC_EXPERIMENTAL_ENABLE_PRIORITY_LB_CHILD_POLICY_CACHE", "true");
+    try {
+      Object fooConfig0 = new Object();
+      PriorityChildConfig priorityChildConfig0 =
+          new PriorityChildConfig(newChildConfig(fooLbProvider, fooConfig0), true);
+      Object fooConfig1 = new Object();
+      PriorityChildConfig priorityChildConfig1 =
+          new PriorityChildConfig(newChildConfig(fooLbProvider, fooConfig1), true);
 
-    PriorityLbConfig priorityLbConfig =
-        new PriorityLbConfig(ImmutableMap.of("p0", priorityChildConfig0), ImmutableList.of("p0"));
-    priorityLb.acceptResolvedAddresses(
-        ResolvedAddresses.newBuilder()
-            .setAddresses(ImmutableList.<EquivalentAddressGroup>of())
-            .setLoadBalancingPolicyConfig(priorityLbConfig)
-            .build());
-    LoadBalancer fooLb0 = Iterables.getOnlyElement(fooBalancers);
-    Status status = Status.DATA_LOSS.withDescription("fake error");
-    priorityLb.handleNameResolutionError(status);
-    verify(fooLb0).handleNameResolutionError(status);
+      PriorityLbConfig priorityLbConfig =
+          new PriorityLbConfig(ImmutableMap.of("p0", priorityChildConfig0), ImmutableList.of("p0"));
+      priorityLb.acceptResolvedAddresses(
+          ResolvedAddresses.newBuilder()
+              .setAddresses(ImmutableList.<EquivalentAddressGroup>of())
+              .setLoadBalancingPolicyConfig(priorityLbConfig)
+              .build());
+      LoadBalancer fooLb0 = Iterables.getOnlyElement(fooBalancers);
+      Status status = Status.DATA_LOSS.withDescription("fake error");
+      priorityLb.handleNameResolutionError(status);
+      verify(fooLb0).handleNameResolutionError(status);
 
-    priorityLbConfig =
-        new PriorityLbConfig(ImmutableMap.of("p1", priorityChildConfig1), ImmutableList.of("p1"));
-    priorityLb.acceptResolvedAddresses(
-        ResolvedAddresses.newBuilder()
-            .setAddresses(ImmutableList.<EquivalentAddressGroup>of())
-            .setLoadBalancingPolicyConfig(priorityLbConfig)
-            .build());
-    assertThat(fooBalancers).hasSize(2);
-    LoadBalancer fooLb1 = Iterables.getLast(fooBalancers);
-    status = Status.UNAVAILABLE.withDescription("fake error");
-    priorityLb.handleNameResolutionError(status);
-    // fooLb0 is deactivated but not yet deleted. However, because it is delisted by the latest
-    // address update, name resolution error will not be propagated to it.
-    verify(fooLb0, never()).shutdown();
-    verify(fooLb0, never()).handleNameResolutionError(status);
-    verify(fooLb1).handleNameResolutionError(status);
+      priorityLbConfig =
+          new PriorityLbConfig(ImmutableMap.of("p1", priorityChildConfig1), ImmutableList.of("p1"));
+      priorityLb.acceptResolvedAddresses(
+          ResolvedAddresses.newBuilder()
+              .setAddresses(ImmutableList.<EquivalentAddressGroup>of())
+              .setLoadBalancingPolicyConfig(priorityLbConfig)
+              .build());
+      assertThat(fooBalancers).hasSize(2);
+      LoadBalancer fooLb1 = Iterables.getLast(fooBalancers);
+      status = Status.UNAVAILABLE.withDescription("fake error");
+      priorityLb.handleNameResolutionError(status);
+      // fooLb0 is deactivated but not yet deleted. However, because it is delisted by the latest
+      // address update, name resolution error will not be propagated to it.
+      verify(fooLb0, never()).shutdown();
+      verify(fooLb0, never()).handleNameResolutionError(status);
+      verify(fooLb1).handleNameResolutionError(status);
+    } finally {
+      System.clearProperty("GRPC_EXPERIMENTAL_ENABLE_PRIORITY_LB_CHILD_POLICY_CACHE");
+    }
   }
 
   @Test


### PR DESCRIPTION
Implements https://github.com/grpc/proposal/blob/master/A115-remove-priority-lb-child-policy-cache.md

## Abstract
A56 describes mechanisms whereby priority LB child policies are cached. There are two cases:

1. When a higher priority child becomes reachable, we deactive the lower-priority children, and remove them only after an expiry.

2. When a child is removed from the LB policy config.

This proposal removes the usage of a cache for case 2.

## Background
The priority LB child policy retention cache consumes excessive memory under the right circumstances (depending on the rate and pattern of locality updates).

This is especially the case when a locality is flapping between failover and primary priorities. For example, notice how priority LB child names increase in the following sequence of locality updates. On each child name update, previous policies are added to the retention cache.

For example, consider the following sequence of updates:

1. P0=[AA, BB], P1=[CC, DD]: P0 will be assigned "child0", P1 will be assigned "child1".
2. P0=[CC], P1=[DD, EE]: P0 will be assigned "child1" (reusing the child name containing "CC" from the previous update), P1 will be assigned "child2" (new child number).
3. P0=[AA, BB], P1=[CC, DD]: P0 will be assigned "child3" (new child number), P1 will be assigned "child1" (reusing the child name containing "CC" from the previous update).

Additionally, priority LB child names are generated with strictly increasing numbers (once a priority LB child name is unconfigured, it will never be configured again). As such, the cache is not providing us value.

## Proposal
Priority LB should disable the child policy retention cache, when a child is removed from its config (i.e., case 2 only).

Note this should be done for Java and Go only.

For C-core, we are actually potentially getting benefit from this behavior due to subchannel pooling, so we're not planning to drop it there until we have the longer-term solution ready.

Temporary environment variable protection
Implementations should provide an environment variable to revert to the previous behavior (child policy cache enabled with 15-minute timer).

This should be kept around for a few releases, and then removed.

Env var name: GRPC_EXPERIMENTAL_ENABLE_PRIORITY_LB_CHILD_POLICY_CACHE.

## Rationale
- Caching the child when it gets removed from the config does not actually accomplish anything useful in the case of choosing a priority within an xDS cluster (which is the primary case where this policy is used), because the hueristic in the cds policy that assigns the child names will never reuse a child name once it has been removed from the config.

- We have seen cases where retaining the children has used up a lot of memory and file descriptors, which has caused problems for users.

- In the long run, we want a better solution involving a separate layer for caching subchannels rather than LB policies, but that will be a separate project to be undertaken later.